### PR TITLE
Implement OAuth token validation and add API check endpoint

### DIFF
--- a/src/app/oauth/page.js
+++ b/src/app/oauth/page.js
@@ -1,4 +1,5 @@
 "use client"
+import axios from "axios";
 import Image from "next/image";
 import { signIn } from "next-auth/react";
 import { useState, useEffect } from "react";
@@ -13,6 +14,16 @@ export default function OAuth({ searchParams }) {
   useEffect(() => {
     async function finishLogin() {
       try {
+        const checkToken = await axios.post("/api/check", { oauth_token: oauth_token });
+        if (checkToken.status !== 200) {
+          if (checkToken.data === "localhost:3000") {
+            window.location.href = "http://localhost:3000";
+            return;
+          } else if (checkToken.data === "capx-test") {
+            window.location.href = "https://capx-test.toolforge.org";
+            return;
+          }
+        }
         const oauth_token = localStorage.getItem("oauth_token");
         const oauth_token_secret = localStorage.getItem("oauth_token_secret");
         const loginResult = await signIn("credentials", {

--- a/src/pages/api/check.js
+++ b/src/pages/api/check.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+export default async function check(req, res) {
+  if (req.method === "POST") {
+    const checkResponse = await axios.post(process.env.CHECK_URL, { oauth_token: req.query.oauth_token });
+    if (checkResponse.data.exists) {
+     if (checkResponse.data.extra !== req.headers.host) {
+       res.status(200).json(checkResponse.data.extra);
+     }
+    } else {
+     res.status(404);
+    }
+  } else {
+    res.status(405);
+  }
+  res.end();
+}

--- a/src/pages/api/login.js
+++ b/src/pages/api/login.js
@@ -4,7 +4,7 @@ export default async function startLogin(req, res) {
   if (req.method === "POST") {
     // Request with no body
     if (req.body.length === 0) {
-      const startLoginResponse = await axios.post(process.env.LOGIN_STEP01_URL);
+      const startLoginResponse = await axios.post(process.env.LOGIN_STEP01_URL, { extra: req.headers.host });
       if (startLoginResponse.data.oauth_callback_confirmed) {
         const { oauth_token, oauth_token_secret } = startLoginResponse.data;
         const redirectURL = process.env.LOGIN_STEP02_URL;


### PR DESCRIPTION
This pull request includes changes to the OAuth login flow and API endpoints to enhance token verification and handling. The most important changes include adding token verification steps, and modifying API endpoints to handle additional data.

Enhancements to OAuth login flow:

* [`src/pages/api/login.js`](diffhunk://#diff-fba175ba980f2b967fa4db00d18c9e754b500769ec72e9cde59a826fb6cc458eL7-R7): Updated the `startLogin` function to include the `host` header in the request body for the initial login step.
* [`src/pages/api/check.js`](diffhunk://#diff-ab7f740ae2b9f7cb53d4a885d1d6be2852ab9a6b93d721e45f8904e354ec1af2R1-R17): Created a new API endpoint to verify the OAuth token by posting to the API and returning appropriate responses based on the verification result from the `host` data saved in the previous step.
* [`src/app/oauth/page.js`](diffhunk://#diff-dc1e9fda9e52cc04c6de2273d4428b9e8c20cda55776e2a92070e2f8a9c7f4aaR2): Added token verification steps in the `finishLogin` function to redirect users based on the token check response. [[1]](diffhunk://#diff-dc1e9fda9e52cc04c6de2273d4428b9e8c20cda55776e2a92070e2f8a9c7f4aaR2) [[2]](diffhunk://#diff-dc1e9fda9e52cc04c6de2273d4428b9e8c20cda55776e2a92070e2f8a9c7f4aaR17-R26)

Downstream from https://github.com/WikiMovimentoBrasil/capx-backend/pull/34