### PR TITLE
Add axios instance with response interceptor for 401 errors

### DIFF
--- a/src/__tests__/services/axiosInstance.test.ts
+++ b/src/__tests__/services/axiosInstance.test.ts
@@ -1,0 +1,38 @@
+import axiosInstance from "@/services/axiosInstance";
+import { signOut } from "next-auth/react";
+
+jest.mock("next-auth/react", () => ({
+  signOut: jest.fn(),
+}));
+
+describe("Axios Instance Interceptors", () => {
+  it("should log out the user and redirect to login page on 401 response with 'Invalid token.'", async () => {
+    const errorResponse = {
+      response: {
+        status: 401,
+        data: { detail: "Invalid token." },
+      },
+    };
+
+    try {
+      await axiosInstance.interceptors.response.handlers[0].rejected(errorResponse);
+    } catch (error) {
+      expect(signOut).toHaveBeenCalledWith({ redirect: true, callbackUrl: "/" });
+    }
+  });
+
+  it("should not log out the user on other errors", async () => {
+    const errorResponse = {
+      response: {
+        status: 500,
+        data: { detail: "Server error." },
+      },
+    };
+
+    try {
+      await axiosInstance.interceptors.response.handlers[0].rejected(errorResponse);
+    } catch (error) {
+      expect(signOut).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import BaseWrapper from "@/components/BaseWrapper";
 import { authOptions } from "@/lib/auth";
+import axiosInstance from "@/services/axiosInstance";
 
 export default async function AuthLayout({
   children,

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { signOut } from "next-auth/react";
-import axios from "axios";
+import axiosInstance from "@/services/axiosInstance";
 import BaseButton from "./BaseButton";
 import Popup from "./Popup";
 import capxPersonIcon from "../../public/static/images/capx_person_icon.svg";
@@ -43,7 +43,7 @@ export default function AuthButton({
       localStorage.removeItem("oauth_token");
       localStorage.removeItem("oauth_token_secret");
 
-      const response = await axios.post("/api/login", null, {
+      const response = await axiosInstance.post("/api/login", null, {
         headers: {
           Accept: "application/json",
           "Content-Type": "application/json",

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import { signOut } from 'next-auth/react';
+
+const axiosInstance = axios.create({
+  baseURL: process.env.BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+axiosInstance.interceptors.response.use(
+  response => response,
+  error => {
+    if (error.response && error.response.status === 401 && error.response.data.detail === 'Invalid token.') {
+      signOut({ redirect: true, callbackUrl: '/' });
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default axiosInstance;


### PR DESCRIPTION
Add Axios instance with interceptors to handle token expiry and logout user on 401 response.

* **src/services/axiosInstance.ts**: Create an Axios instance with interceptors. Add a response interceptor to catch HTTP 401 responses and check if the response data contains `{ detail: 'Invalid token.' }`. If conditions are met, log out the user and redirect to the login page.
* **src/components/AuthButton.tsx**: Import the Axios instance and use it for login requests.
* **src/app/(auth)/layout.tsx**: Import the Axios instance.
* **src/__tests__/services/axiosInstance.test.ts**: Add tests for the Axios instance interceptors to ensure the interceptor logs out the user and redirects to the login page on 401 response.

