### PR TITLE
Handle token expiry by forcing user to logout

### DIFF
--- a/src/app/api/organizations/[id]/route.ts
+++ b/src/app/api/organizations/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import axios from "axios";
+import { handleApiError } from "@/lib/utils/handleApiError";
 
 export async function GET(
   request: Request,
@@ -21,13 +22,7 @@ export async function GET(
 
     return NextResponse.json(response.data);
   } catch (error: any) {
-    return NextResponse.json(
-      {
-        error: "Failed to fetch organization",
-        details: error.response?.data || error.message,
-      },
-      { status: error.response?.status || 500 }
-    );
+    return handleApiError(error, "Organization fetch");
   }
 }
 
@@ -53,13 +48,6 @@ export async function PUT(
 
     return NextResponse.json(updateResponse.data);
   } catch (error: any) {
-    console.error("Error details:", error.response?.data || error);
-    return NextResponse.json(
-      {
-        error: "Failed to update organization",
-        details: error.response?.data || error.message,
-      },
-      { status: error.response?.status || 500 }
-    );
+    return handleApiError(error, "Organization update");
   }
 }

--- a/src/app/api/organizations/route.ts
+++ b/src/app/api/organizations/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import axios from "axios";
+import { handleApiError } from "@/lib/utils/handleApiError";
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
@@ -12,14 +13,6 @@ export async function GET(request: NextRequest) {
     });
     return NextResponse.json(response.data);
   } catch (error: any) {
-    console.error("Error details:", {
-      status: error.response?.status,
-      data: error.response?.data,
-      message: error.message,
-    });
-    return NextResponse.json(
-      { error: "Failed to fetch organizations" },
-      { status: error.response?.status || 500 }
-    );
+    return handleApiError(error, "Organizations fetch");
   }
 }

--- a/src/app/api/profile/[id]/route.ts
+++ b/src/app/api/profile/[id]/route.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { NextRequest, NextResponse } from "next/server";
-
+import { handleApiError } from "@/lib/utils/handleApiError";
 export async function PUT(
   request: NextRequest,
   { params }: { params: { id: string } }
@@ -28,14 +28,7 @@ export async function PUT(
 
     return NextResponse.json(response.data);
   } catch (error: any) {
-    console.error("PUT request error:", error.response?.data || error.message);
-    return NextResponse.json(
-      {
-        error: "Failed to update user profile",
-        details: error.response?.data || error.message,
-      },
-      { status: error.response?.status || 500 }
-    );
+    return handleApiError(error, "Profile update");
   }
 }
 
@@ -57,13 +50,6 @@ export async function GET(
 
     return NextResponse.json(response.data);
   } catch (error: any) {
-    console.error("GET request error:", error.response?.data || error.message);
-    return NextResponse.json(
-      {
-        error: "Failed to get user profile",
-        details: error.response?.data || error.message,
-      },
-      { status: error.response?.status || 500 }
-    );
+    return handleApiError(error, "Profile fetch");
   }
 }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,3 +1,4 @@
+import { handleApiError } from "@/lib/utils/handleApiError";
 import axios from "axios";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -23,6 +24,12 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
   } catch (error: any) {
+    if (
+      error.response?.status === 401 &&
+      error.response?.data?.detail === "Invalid token."
+    ) {
+      return handleApiError(error, "Profile fetch");
+    }
     console.error(
       "Error fetching user profile:",
       error.response?.data || error.message
@@ -71,11 +78,7 @@ export async function PUT(request: NextRequest) {
       );
     }
   } catch (error) {
-    console.error("PUT request error:", error);
-    return NextResponse.json(
-      { error: "Failed to update user profile." },
-      { status: 500 }
-    );
+    return handleApiError(error, "Profile update");
   }
 }
 
@@ -93,15 +96,11 @@ export async function OPTIONS(request: NextRequest) {
         },
       }
     );
-    // Removing "user" key/value
     const { user, ...formFields } = response.data.actions.PUT;
 
     return NextResponse.json(formFields);
   } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to fetch options" },
-      { status: 500 }
-    );
+    return handleApiError(error, "Profile options");
   }
 }
 
@@ -129,9 +128,6 @@ export async function DELETE(request: NextRequest) {
       );
     }
   } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to delete user profile" },
-      { status: 500 }
-    );
+    return handleApiError(error, "Profile delete");
   }
 }

--- a/src/lib/utils/apiClient.ts
+++ b/src/lib/utils/apiClient.ts
@@ -1,0 +1,21 @@
+import { signOut } from "next-auth/react";
+
+export async function handleApiResponse(response: Response) {
+  const data = await response.json();
+
+  if (response.status === 401 && data.shouldLogout) {
+    await signOut({ redirect: true, callbackUrl: "/" });
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(data.error || "An error occurred");
+  }
+
+  return data;
+}
+
+export async function fetchFromApi(url: string, options: RequestInit = {}) {
+  const response = await fetch(url, options);
+  return handleApiResponse(response);
+}

--- a/src/lib/utils/handleApiError.ts
+++ b/src/lib/utils/handleApiError.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+export function handleApiError(error: any, routeName: string) {
+  if (
+    error.response?.status === 401 &&
+    error.response?.data?.detail === "Invalid token."
+  ) {
+    return NextResponse.json(
+      { error: "Invalid token", shouldLogout: true },
+      { status: 401 }
+    );
+  }
+
+  console.error(`${routeName} error:`, {
+    error: error.response?.data || error.message,
+    status: error.response?.status,
+  });
+
+  return NextResponse.json(
+    { error: `Failed to process ${routeName} request` },
+    { status: error.response?.status || 500 }
+  );
+}


### PR DESCRIPTION
# Add Invalid Token Handling to Organization Profile Hook

## Changes Made
- Added token invalidation handling across all API calls in `useOrganizationProfile` hook
- Implemented automatic logout and redirect when receiving 401 unauthorized responses
- Added `fetchFromApi` utility to standardize API response handling
- Added `handleInvalidToken` function to centralize logout logic

## Technical Details
- Added error handling for 401 responses in:
  - `fetchUserProfile`
  - `fetchOrganizationById`
  - `updateOrganization`
- Integrated with `next-auth` signOut functionality
- Ensures consistent redirection to root page on authentication failures
- Uses `fetchFromApi` to process API responses uniformly

## Testing
To test these changes:
1. Try accessing organization profile with an invalid/expired token
2. Verify automatic logout occurs
3. Confirm redirect to root page
4. Check that error states are properly handled

## Related Issues
- Fixes issue where users weren't being logged out on invalid tokens
- Improves security by handling unauthorized access consistently
