### PR TITLE
Fix organization profile layout, add translations and improve avatar popup layout

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -55,7 +55,7 @@
   "body-profile-section-title-events": "Events",
   "body-profile-section-title-documents": "Documents",
   "body-profile-section-title-main-projects": "Main projects",
-
+  "body-profile-section-affiliation-dropdown-menu": "Select your organization from the dropdown menu.",
   "profiency-level-not-proficient": "Not proficient",
   "profiency-level-basic": "Basic",
   "profiency-level-intermediate": "Intermediate",
@@ -168,6 +168,7 @@
   "edit-profile-wanted-capacities": "Select skills you are willing to learn from the Capacity Directory. Try to choose the most specific ones.",
   "edit-profile-choose-an-option": "Choose an option",
   "edit-profile-add-link": "Add link",
+  "edit-profile-add-language": "Add language",
   "edit-profile-save-organization": "Save organization",
   "edit-profile-main-projects": "Main Projects",
   "edit-profile-add-projects": "Add projects",

--- a/src/app/(auth)/home/components/AuthenticatedMainSection.tsx
+++ b/src/app/(auth)/home/components/AuthenticatedMainSection.tsx
@@ -78,7 +78,7 @@ export default function AuthenticatedMainSection({
     <section
       className={
         (darkMode ? "bg-capx-dark-bg" : "bg-capx-dark-box-bg") +
-        "flex flex-col items-center justify-start w-full mx-auto px-4 px-[132px]"
+        "flex flex-col items-center justify-start w-full max-w-screen-xl mx-auto px-8"
       }
     >
       <div className="flex flex-col items-center justify-between w-full py-16 md:py-32 gap-16">
@@ -221,7 +221,7 @@ export default function AuthenticatedMainSection({
   return (
     <>
       <section className="flex flex-col items-center justify-start w-full mx-auto ">
-        <div className="flex flex-row items-center justify-between w-full py-[128px] gap-8 px-[132px]">
+        <div className="flex flex-row items-center justify-between w-full py-[128px] gap-8 max-w-screen-xl mx-auto px-8">
           <div className="flex flex-col items-center md:items-start w-full md:w-1/2 lg:w-2/3">
             <h1
               className={

--- a/src/app/(auth)/home/components/AuthenticatedMainSection.tsx
+++ b/src/app/(auth)/home/components/AuthenticatedMainSection.tsx
@@ -9,7 +9,9 @@ import AuthButton from "@/components/AuthButton";
 import BaseButton from "@/components/BaseButton";
 import { useApp } from "@/contexts/AppContext";
 import { useTheme } from "@/contexts/ThemeContext";
-
+import { useState } from "react";
+import Popup from "@/components/Popup";
+import capxPersonIcon from "@/public/static/images/capx_person_icon.svg";
 interface AuthenticatedMainSectionProps {
   pageContent: any;
 }
@@ -20,6 +22,7 @@ export default function AuthenticatedMainSection({
   const { isMobile } = useApp();
   const { darkMode } = useTheme();
   const router = useRouter();
+  const [showPopup, setShowPopup] = useState(false);
 
   const secondarySection = isMobile ? (
     <section
@@ -94,64 +97,79 @@ export default function AuthenticatedMainSection({
         </div>
         <div className="flex items-center w-full gap-[86px]">
           <div className="flex items-center flex-col gap-[24px]">
-            <Image
-              src={SecondarySectionIllustration01}
-              alt="Secondary section illustration"
-              width={520}
-              height={520}
-            />
-            <p
-              className={
-                (darkMode ? "text-[#FFF]" : "text-[#053749]") +
-                " text-center text-[48px] not-italic font-normal leading-[59px]"
-              }
+            <button
+              className="w-full h-full"
+              onClick={() => setShowPopup(true)}
             >
-              {
-                pageContent[
-                  "body-loggedin-home-secondary-section-image01-description"
-                ]
-              }
-            </p>
+              <Image
+                src={SecondarySectionIllustration01}
+                alt="Secondary section illustration"
+                width={520}
+                height={520}
+              />
+              <p
+                className={
+                  (darkMode ? "text-[#FFF]" : "text-[#053749]") +
+                  " text-center text-[48px] not-italic font-normal leading-[59px]"
+                }
+              >
+                {
+                  pageContent[
+                    "body-loggedin-home-secondary-section-image01-description"
+                  ]
+                }
+              </p>
+            </button>
           </div>
           <div className="flex items-center flex-col gap-[24px]">
-            <Image
-              src={SecondarySectionIllustration02}
-              alt="Secondary section illustration"
-              width={520}
-              height={520}
-            />
-            <p
-              className={
-                (darkMode ? "text-[#FFF]" : "text-[#053749]") +
-                " text-center text-[48px] not-italic font-normal leading-[59px]"
-              }
+            <button
+              className="w-full h-full"
+              onClick={() => setShowPopup(true)}
             >
-              {
-                pageContent[
-                  "body-loggedin-home-secondary-section-image02-description"
-                ]
-              }
-            </p>
+              <Image
+                src={SecondarySectionIllustration02}
+                alt="Secondary section illustration"
+                width={520}
+                height={520}
+              />
+              <p
+                className={
+                  (darkMode ? "text-[#FFF]" : "text-[#053749]") +
+                  " text-center text-[48px] not-italic font-normal leading-[59px]"
+                }
+              >
+                {
+                  pageContent[
+                    "body-loggedin-home-secondary-section-image02-description"
+                  ]
+                }
+              </p>
+            </button>
           </div>
           <div className="flex items-center flex-col gap-[24px]">
-            <Image
-              src={SecondarySectionIllustration03}
-              alt="Secondary section illustration"
-              width={520}
-              height={520}
-            />
-            <p
-              className={
-                (darkMode ? "text-[#FFF]" : "text-[#053749]") +
-                " text-center text-[48px] not-italic font-normal leading-[59px]"
-              }
+            <button
+              className="w-full h-full"
+              onClick={() => setShowPopup(true)}
             >
-              {
-                pageContent[
-                  "body-loggedin-home-secondary-section-image03-description"
-                ]
-              }
-            </p>
+              <Image
+                src={SecondarySectionIllustration03}
+                alt="Secondary section illustration"
+                width={520}
+                height={520}
+              />
+              <p
+                className={
+                  (darkMode ? "text-[#FFF]" : "text-[#053749]") +
+                  " text-center text-[48px] not-italic font-normal leading-[59px]"
+                }
+              >
+                {
+                  pageContent[
+                    "body-loggedin-home-secondary-section-image03-description"
+                  ]
+                }
+              </p>
+            </button>
           </div>
         </div>
       </div>
@@ -214,6 +232,19 @@ export default function AuthenticatedMainSection({
           </div>
         </section>
         {secondarySection}
+        {showPopup && (
+          <Popup
+            onContinue={() => setShowPopup(false)}
+            onClose={() => setShowPopup(false)}
+            image={capxPersonIcon}
+            title={pageContent["component-under-development-dialog"]}
+            closeButtonLabel={pageContent["auth-dialog-button-close"]}
+            continueButtonLabel={
+              pageContent["body-loggedin-home-main-section-button02"]
+            }
+            customClass={`${darkMode ? "bg-[#005B3F]" : "bg-white"}`}
+          />
+        )}
       </>
     );
   }
@@ -274,6 +305,19 @@ export default function AuthenticatedMainSection({
           </div>
         </div>
         {secondarySection}
+        {showPopup && (
+          <Popup
+            onContinue={() => setShowPopup(false)}
+            onClose={() => setShowPopup(false)}
+            image={capxPersonIcon}
+            title={pageContent["component-under-development-dialog"]}
+            closeButtonLabel={pageContent["auth-dialog-button-close"]}
+            continueButtonLabel={
+              pageContent["body-loggedin-home-main-section-button02"]
+            }
+            customClass={`${darkMode ? "bg-[#005B3F]" : "bg-white"}`}
+          />
+        )}
       </section>
     </>
   );

--- a/src/app/(auth)/organization_profile/components/ContactsSection.tsx
+++ b/src/app/(auth)/organization_profile/components/ContactsSection.tsx
@@ -107,7 +107,7 @@ export const ContactsSection = ({
 
   return (
     <section className="w-full max-w-screen-xl py-8">
-      <div className="flex flex-row flex pl-0 pr-[13px] py-[6px] items-center gap-[4px] rounded-[8px] mb-6">
+      <div className="flex flex-row flex pl-0 pr-[13px] py-[6px] items-center gap-4 rounded-[8px] mb-6">
         <div className="relative w-[48px] h-[48px]">
           <Image
             src={darkMode ? WikimediaIconWhite : WikimediaIcon}

--- a/src/app/(auth)/organization_profile/components/DocumentsList.tsx
+++ b/src/app/(auth)/organization_profile/components/DocumentsList.tsx
@@ -29,7 +29,11 @@ export const DocumentsList = ({
   return (
     <section className="flex flex-col gap-4">
       <div className="flex flex-row gap-4 items-center">
-        <div className="relative w-[20px] h-[20px]">
+        <div
+          className={`relative ${
+            isMobile ? "w-[20px] h-[20px]" : "w-[42px] h-[42px]"
+          }`}
+        >
           <Image
             src={darkMode ? WikimediaIconWhite : WikimediaIcon}
             alt="Wikimedia icon"

--- a/src/app/(auth)/organization_profile/components/NewsSection.tsx
+++ b/src/app/(auth)/organization_profile/components/NewsSection.tsx
@@ -77,8 +77,8 @@ export const NewsSection = ({ ids }: NewsProps) => {
 
   return (
     <section className="w-full max-w-screen-xl py-8">
-      <div className="flex flex-row flex pl-0 pr-[13px] py-[6px] items-center gap-[4px] rounded-[8px] mb-6">
-        <div className="relative w-[20px] h-[20px] md:w-[48px] md:h-[48px]">
+      <div className="flex flex-row flex pl-0 pr-[13px] py-[6px] items-center gap-4 rounded-[8px] mb-6">
+        <div className="relative w-[20px] h-[20px] md:w-[42px] md:h-[48px]">
           <Image
             src={darkMode ? WikimediaIconWhite : WikimediaIcon}
             alt="Wikimedia"

--- a/src/app/(auth)/organization_profile/components/ProjectsEventsList.tsx
+++ b/src/app/(auth)/organization_profile/components/ProjectsEventsList.tsx
@@ -29,7 +29,11 @@ export const ProjectsEventsList = ({
   return (
     <section className="flex flex-col gap-4">
       <div className="flex flex-row gap-4 items-center">
-        <div className="relative w-[20px] h-[20px]">
+        <div
+          className={`relative ${
+            isMobile ? "w-[20px] h-[20px]" : "w-[42px] h-[42px]"
+          }`}
+        >
           <Image
             src={darkMode ? WikimediaIconWhite : WikimediaIcon}
             alt="Wikimedia icon"

--- a/src/app/(auth)/organization_profile/edit/page.tsx
+++ b/src/app/(auth)/organization_profile/edit/page.tsx
@@ -55,6 +55,7 @@ import EventsFormItem from "../components/EventsFormItem";
 import NewsFormItem from "../components/NewsFormItem";
 import DocumentFormItem from "../components/DocumentFormItem";
 import { formatWikiImageUrl } from "@/lib/utils/fetchWikimediaData";
+import LoadingState from "@/components/LoadingState";
 
 export default function EditOrganizationProfilePage() {
   const router = useRouter();
@@ -63,6 +64,7 @@ export default function EditOrganizationProfilePage() {
   const { darkMode } = useTheme();
   const { isMobile, pageContent } = useApp();
   const [isInitialized, setIsInitialized] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   // Documents setters
   const {
@@ -548,7 +550,7 @@ export default function EditOrganizationProfilePage() {
       await updateOrganization(updatedFormData as Partial<OrganizationType>);
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      router.push(`/organization_profile?t=${Date.now()}`);
+      router.push(`/organization_profile`);
     } catch (error) {
       console.error("Error processing form:", error);
     }
@@ -813,19 +815,17 @@ export default function EditOrganizationProfilePage() {
   };
 
   // Load user profile data
-  const { userProfile } = useUserProfile();
+  const { userProfile, isLoading: isUserLoading } = useUserProfile();
 
   const userImage = userProfile?.profile_image;
 
-  if (!isOrgManager) {
-    return (
-      <div className="flex justify-center items-center min-h-screen">
-        <p className="text-center">
-          You are not a manager of any organization. Please contact an
-          administrator.
-        </p>
-      </div>
-    );
+  if (isUserLoading || isOrganizationLoading) {
+    return <LoadingState />;
+  }
+
+  if (!token || !isOrgManager) {
+    router.replace("/organization_profile");
+    return <LoadingState />;
   }
 
   if (isMobile) {

--- a/src/app/(auth)/organization_profile/page.tsx
+++ b/src/app/(auth)/organization_profile/page.tsx
@@ -26,8 +26,10 @@ import { useEffect } from "react";
 import { useOrganization } from "@/hooks/useOrganizationProfile";
 import { DocumentsList } from "./components/DocumentsList";
 import NoAvatarIcon from "@/public/static/images/no_avatar.svg";
-import { useOrganizationType } from "@/hooks/useOrganizationType";
 import { formatWikiImageUrl } from "@/lib/utils/fetchWikimediaData";
+import LoadingState from "@/components/LoadingState";
+import { useUserProfile } from "@/hooks/useUserProfile";
+
 export default function OrganizationProfilePage() {
   const { darkMode } = useTheme();
   const { isMobile, pageContent } = useApp();
@@ -35,25 +37,25 @@ export default function OrganizationProfilePage() {
   const { data: session } = useSession();
   const token = session?.user?.token;
 
-  const { organization, isLoading, error, isOrgManager, refetch } =
-    useOrganization(token);
-
-  /*   const orgType = organization?.type || 0; //TODO: Make better assumption
+  const {
+    organization,
+    isLoading: isOrganizationLoading,
+    error,
+    isOrgManager,
+    refetch,
+  } = useOrganization(token);
 
   const {
-    organizationType,
-    fetchOrganizationType,
-    fetchOrganizationTypeById,
-    isLoading: isOrganizationTypeLoading,
-    error: isOrganizationTypeError,
-  } = useOrganizationType(token, orgType);
-
-  console.log(organizationType); */
+    userProfile,
+    isLoading: isUserLoading,
+    error: isUserError,
+  } = useUserProfile();
 
   useEffect(() => {
     const refreshData = async () => {
       await refetch();
     };
+
     refreshData();
   }, []);
 
@@ -62,6 +64,10 @@ export default function OrganizationProfilePage() {
       console.error("Error fetching organization:", error);
     }
   }, [error, organization]);
+
+  if (isOrganizationLoading || isUserLoading) {
+    return <LoadingState />;
+  }
 
   if (isMobile) {
     return (
@@ -188,9 +194,7 @@ export default function OrganizationProfilePage() {
                 <CapacitiesList
                   items={organization?.available_capacities || []}
                   icon={darkMode ? EmojiIconWhite : EmojiIcon}
-                  title={
-                    pageContent["body-profile-section-title-available-capacity"]
-                  }
+                  title={pageContent["body-profile-available-capacities-title"]}
                   customClass={`font-[Montserrat] text-[14px] not-italic font-extrabold leading-[normal]
                     `}
                 />

--- a/src/app/(auth)/profile/components/AvatarSelectionPopup.tsx
+++ b/src/app/(auth)/profile/components/AvatarSelectionPopup.tsx
@@ -20,7 +20,7 @@ export default function AvatarSelectionPopup({
   onUpdate,
 }: AvatarSelectionPopupProps) {
   const { avatars, isLoading } = useAvatars();
-  const { pageContent } = useApp();
+  const { pageContent, isMobile } = useApp();
   const [tempSelectedId, setTempSelectedId] = useState(selectedAvatarId);
   const { darkMode } = useTheme();
 
@@ -42,28 +42,95 @@ export default function AvatarSelectionPopup({
     );
   }
 
+  if (isMobile) {
+    return (
+      <>
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-40" />
+        <div
+          className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 ${
+            darkMode ? "bg-[#053749] text-white" : "bg-white text-[#053749]"
+          } z-50 rounded-lg shadow-xl h-[477px] w-[273px] flex flex-col`}
+        >
+          <div className="flex justify-between items-center p-6 border-b border-gray-200">
+            <h2 className={`font-[Montserrat] text-[16px] font-bold`}>
+              {pageContent["edit-profile-choose-an-option"]}
+            </h2>
+            <button
+              onClick={onClose}
+              className="text-gray-500 hover:text-gray-700"
+            >
+              <Image src={CloseIcon} alt="Close" width={24} height={24} />
+            </button>
+          </div>
+
+          <div className="overflow-y-auto flex-1 p-6">
+            <div className="grid grid-cols-2 gap-4">
+              {avatars?.map((avatar) => (
+                <button
+                  key={avatar.id}
+                  onClick={() => setTempSelectedId(avatar.id)}
+                  className="flex justify-center"
+                >
+                  <div
+                    className={`w-[100px] h-[100px] border rounded-lg transition-colors ${
+                      tempSelectedId === avatar.id
+                        ? "border-2 border-[#851970]"
+                        : "border border-black hover:border-[#851970]"
+                    }`}
+                  >
+                    <div className="relative w-full h-full">
+                      <Image
+                        src={avatar.avatar_url}
+                        alt={`Avatar ${avatar.id}`}
+                        fill
+                        className="object-contain"
+                      />
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="p-6 border-t border-gray-200">
+            <div className="flex gap-4">
+              <BaseButton
+                onClick={onClose}
+                label={pageContent["auth-dialog-button-close"]}
+                customClass={`flex-1 border ${
+                  darkMode
+                    ? "border-white text-white"
+                    : "border-[#053749] text-[#053749]"
+                } rounded-md py-2 font-[Montserrat] text-[14px] font-bold`}
+              />
+              <BaseButton
+                onClick={handleUpdate}
+                label={pageContent["edit-profile-update"]}
+                customClass="flex-1 bg-[#851970] text-white rounded-md py-2 font-[Montserrat] text-[14px] font-bold"
+              />
+            </div>
+          </div>
+        </div>
+      </>
+    );
+  }
+
   return (
     <>
       <div className="fixed inset-0 bg-black bg-opacity-50 z-40" />
       <div
-        className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 ${
-          darkMode ? "bg-[#053749] text-white" : "bg-white text-[#053749]"
-        } z-50 rounded-lg shadow-xl h-[477px] w-[273px] flex flex-col`}
+        className={`fixed w-[600px] h-[919px] top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 overflow-y-auto ${
+          darkMode ? "bg-[#005B3F] text-white" : "bg-white text-[#053749]"
+        } z-50 rounded-lg shadow-xl flex flex-col`}
       >
-        <div className="flex justify-between items-center p-6 border-b border-gray-200">
-          <h2 className={`font-[Montserrat] text-[16px] font-bold`}>
+        <div className="flex justify-center items-center p-6 border-b border-gray-200">
+          <h2 className={`font-[Montserrat] text-[48px] font-bold`}>
             {pageContent["edit-profile-choose-an-option"]}
           </h2>
-          <button
-            onClick={onClose}
-            className="text-gray-500 hover:text-gray-700"
-          >
-            <Image src={CloseIcon} alt="Close" width={24} height={24} />
-          </button>
         </div>
 
-        <div className="overflow-y-auto flex-1 p-6">
-          <div className="grid grid-cols-2 gap-4">
+        <div className="flex overflow-y-auto scrollbar-hide flex-1 p-6 justify-center">
+          <div className="grid grid-cols-2 gap-4 w-fit">
             {avatars?.map((avatar) => (
               <button
                 key={avatar.id}
@@ -71,7 +138,7 @@ export default function AvatarSelectionPopup({
                 className="flex justify-center"
               >
                 <div
-                  className={`w-[100px] h-[100px] border rounded-lg transition-colors ${
+                  className={`w-[180px] h-[180px] border rounded-lg transition-colors ${
                     tempSelectedId === avatar.id
                       ? "border-2 border-[#851970]"
                       : "border border-black hover:border-[#851970]"
@@ -96,16 +163,16 @@ export default function AvatarSelectionPopup({
             <BaseButton
               onClick={onClose}
               label={pageContent["auth-dialog-button-close"]}
-              customClass={`flex-1 border ${
+              customClass={`flex-1 border w-1/2 ${
                 darkMode
                   ? "border-white text-white"
                   : "border-[#053749] text-[#053749]"
-              } rounded-md py-2 font-[Montserrat] text-[14px] font-bold`}
+              } rounded-md py-2 font-[Montserrat] text-[24px] font-bold`}
             />
             <BaseButton
               onClick={handleUpdate}
               label={pageContent["edit-profile-update"]}
-              customClass="flex-1 bg-[#851970] text-white rounded-md py-2 font-[Montserrat] text-[14px] font-bold"
+              customClass="flex-1 w-1/2 bg-[#851970] text-white rounded-md py-2 font-[Montserrat] text-[24px] font-bold"
             />
           </div>
         </div>

--- a/src/app/(auth)/profile/components/ProfileHeader.tsx
+++ b/src/app/(auth)/profile/components/ProfileHeader.tsx
@@ -112,7 +112,7 @@ export default function ProfileHeader({
           src={avatarUrl}
           alt={pageContent["navbar-user-profile"]}
           fill
-          className="object-cover border rounded-[8px]"
+          className="object-cover"
           unoptimized
         />
       </div>

--- a/src/app/(auth)/profile/edit/page.tsx
+++ b/src/app/(auth)/profile/edit/page.tsx
@@ -453,7 +453,7 @@ export default function EditProfilePage() {
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Welcome!
+                  {pageContent["edit-profile-welcome"]}
                 </h1>
                 <div className="flex items-center gap-[6px]">
                   <div className="relative w-[24px] h-[24px]">
@@ -493,7 +493,7 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     } font-[Montserrat] text-[16px] font-bold`}
                   >
-                    Image profile
+                    {pageContent["edit-profile-image-title"]}
                   </h2>
                 </div>
 
@@ -510,7 +510,7 @@ export default function EditProfilePage() {
 
                 <BaseButton
                   onClick={() => setShowAvatarPopup(true)}
-                  label= {pageContent["edit-profile-choose-avatar"]}
+                  label={pageContent["edit-profile-choose-avatar"]}
                   customClass={`w-full flex px-[13px] py-[6px] pb-[6px] items-center rounded-[4px] ${
                     darkMode
                       ? "bg-capx-light-bg text-[#053749]"
@@ -559,8 +559,7 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      I consent displaying my Wikidata item image on CapX
-                      profile (if existent).
+                      {pageContent["edit-profile-consent-wikidata"]}
                     </span>
                   </div>
                 </div>
@@ -605,7 +604,7 @@ export default function EditProfilePage() {
                           darkMode ? "text-white" : "text-[#053749]"
                         }`}
                       >
-                        Mini bio
+                        {pageContent["edit-profile-mini-bio"]}
                       </h2>
                     </div>
                   </div>
@@ -615,7 +614,9 @@ export default function EditProfilePage() {
                       onChange={(e) =>
                         setFormData({ ...formData, about: e.target.value })
                       }
-                      placeholder="Write a short description about yourself."
+                      placeholder={
+                        pageContent["edit-profile-mini-bio-placeholder"]
+                      }
                       className={`w-full font-[Montserrat] text-[13px] not-italic font-normal leading-[normal] bg-transparent resize-none min-h-[100px] rounded-[4px] border-[1px] border-[solid] border-[#053749] px-[4px] ${
                         darkMode
                           ? "text-white placeholder-gray-400"
@@ -628,8 +629,7 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     }`}
                   >
-                    Select skills you already have from the Capacity Directory.
-                    Try to choose the most specific ones.{" "}
+                    {pageContent["edit-profile-select-skills"]}
                   </span>
                 </div>
               </div>
@@ -650,7 +650,7 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Known capacities
+                      {pageContent["body-profile-section-title-known-capacity"]}
                     </h2>
                   </div>
                   <div
@@ -693,8 +693,7 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     }`}
                   >
-                    Select skills you already have from the Capacity Directory.
-                    Try to choose the most specific ones.
+                    {pageContent["edit-profile-known-capacities-description"]}
                   </span>
                 </div>
 
@@ -712,7 +711,11 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Available capacities
+                      {
+                        pageContent[
+                          "body-profile-section-title-available-capacity"
+                        ]
+                      }
                     </h2>
                   </div>
                   <div
@@ -776,7 +779,11 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Wanted capacities
+                      {
+                        pageContent[
+                          "body-profile-section-title-wanted-capacity"
+                        ]
+                      }
                     </h2>
                   </div>
                   <div
@@ -819,8 +826,7 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     }`}
                   >
-                    Select skills you are willing to learn from the Capacity
-                    Directory. Try to choose the most specific ones.
+                    {pageContent["edit-profile-wanted-capacities-description"]}
                   </span>
                 </div>
 
@@ -838,7 +844,7 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Languages
+                      {pageContent["body-profile-languages-title"]}
                     </h2>
                   </div>
 
@@ -873,13 +879,27 @@ export default function EditProfilePage() {
                               : "border-[#053749] text-[#829BA4]"
                           }`}
                         >
-                          <option value="0">Not proficient</option>
-                          <option value="1">Basic</option>
-                          <option value="2">Intermediate</option>
-                          <option value="3">Advanced</option>
-                          <option value="4">Almost native</option>
-                          <option value="5">Professional proficiency</option>
-                          <option value="n">Native</option>
+                          <option value="0">
+                            {pageContent["profiency-level-not-proficient"]}
+                          </option>
+                          <option value="1">
+                            {pageContent["profiency-level-basic"]}
+                          </option>
+                          <option value="2">
+                            {pageContent["profiency-level-intermediate"]}
+                          </option>
+                          <option value="3">
+                            {pageContent["profiency-level-advanced"]}
+                          </option>
+                          <option value="4">
+                            {pageContent["profiency-level-almost-native"]}
+                          </option>
+                          <option value="5">
+                            {pageContent["profiency-level-professional"]}
+                          </option>
+                          <option value="n">
+                            {pageContent["profiency-level-native"]}
+                          </option>
                         </select>
                         <button
                           onClick={() => handleRemoveLanguage(index)}
@@ -949,7 +969,7 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Alternative Wikimedia Account
+                      {pageContent["body-profile-box-title-alt-wiki-acc"]}
                     </h2>
                   </div>
                   <input
@@ -973,7 +993,7 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     }`}
                   >
-                    Share another Wikimedia username if you have one.
+                    {pageContent["edit-profile-share-username"]}
                   </span>
                 </div>
 
@@ -991,7 +1011,7 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Affiliation
+                      {pageContent["body-profile-section-title-affiliation"]}
                     </h2>
                   </div>
                   <div className="relative">
@@ -1009,7 +1029,9 @@ export default function EditProfilePage() {
                           : "border-[#053749] text-[#829BA4]"
                       } border`}
                     >
-                      <option value="">{pageContent["edit-profile-insert-item"]}</option>
+                      <option value="">
+                        {pageContent["edit-profile-insert-item"]}
+                      </option>
                       {Object.entries(affiliations).map(([id, name]) => (
                         <option key={id} value={id}>
                           {name}
@@ -1030,7 +1052,11 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     }`}
                   >
-                    Select your organization from the dropdown menu.
+                    {
+                      pageContent[
+                        "body-profile-section-affiliation-dropdown-menu"
+                      ]
+                    }
                   </span>
                 </div>
 
@@ -1048,7 +1074,7 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Territory
+                      {pageContent["body-profile-section-title-territory"]}
                     </h2>
                   </div>
                   <div className="relative">
@@ -1066,7 +1092,9 @@ export default function EditProfilePage() {
                           : "border-[#053749] text-[#829BA4]"
                       } border`}
                     >
-                      <option value="">{pageContent["edit-profile-insert-item"]}</option>
+                      <option value="">
+                        {pageContent["edit-profile-insert-item"]}
+                      </option>
                       {Object.entries(territories).map(([id, name]) => (
                         <option key={id} value={id}>
                           {name}
@@ -1087,7 +1115,7 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     }`}
                   >
-                    Inform your geographic location by region or country.
+                    {pageContent["edit-profile-territory"]}
                   </span>
                 </div>
 
@@ -1105,7 +1133,7 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Wikidata Item
+                      {pageContent["edit-profile-wikidata-item"]}
                     </h2>
                   </div>
                   <div className="flex items-center gap-2 py-[6px] ">
@@ -1148,8 +1176,7 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     }`}
                   >
-                    I consent displaying my Wikidata item on CapX profile (if
-                    existent).
+                    {pageContent["edit-profile-consent-wikidata-item"]}
                   </span>
                 </div>
 
@@ -1167,7 +1194,7 @@ export default function EditProfilePage() {
                         darkMode ? "text-white" : "text-[#053749]"
                       }`}
                     >
-                      Wikimedia Projects
+                      {pageContent["body-profile-wikimedia-projects-title"]}
                     </h2>
                   </div>
                   <div className="relative">
@@ -1190,7 +1217,9 @@ export default function EditProfilePage() {
                           : "border-[#053749] text-[#829BA4]"
                       } border`}
                     >
-                      <option value="">{pageContent["edit-profile-insert-project"]}</option>
+                      <option value="">
+                        {pageContent["edit-profile-insert-project"]}
+                      </option>
                       {Object.entries(wikimediaProjects).map(([id, name]) => (
                         <option key={id} value={id}>
                           {name}
@@ -1229,7 +1258,9 @@ export default function EditProfilePage() {
                               : "border-[#053749] text-[#829BA4]"
                           } border`}
                         >
-                          <option value="">{pageContent["edit-profile-insert-project"]}</option>
+                          <option value="">
+                            {pageContent["edit-profile-insert-project"]}
+                          </option>
                           {Object.entries(wikimediaProjects).map(
                             ([id, name]) => (
                               <option key={id} value={id}>
@@ -1267,7 +1298,7 @@ export default function EditProfilePage() {
                       darkMode ? "text-white" : "text-[#053749]"
                     }`}
                   >
-                    Inform the Wikimedia Projects you have interest in.
+                    {pageContent["edit-profile-add-more-projects-description"]}
                   </span>
                 </div>
               </div>
@@ -1321,17 +1352,13 @@ export default function EditProfilePage() {
           isMobile ? "mt-[80px]" : "mt-[64px]"
         }`}
       >
-        <div
-          className={`flex flex-col gap-6 ${
-            isMobile ? "" : "mx-[80px]"
-          } mx-auto`}
-        >
+        <div className={`flex flex-col gap-6mx-[80px] mx-auto`}>
           {/* Image Profile Section */}
 
           <div className="flex flex-row gap-12">
             <div className="flex flex-col gap-4 w-1/2">
               <div className="flex flex-row gap-1 items-center">
-                <div className="relative w-[20px] h-[20px]">
+                <div className="relative w-[48px] h-[48px]">
                   <Image
                     src={darkMode ? AccountBoxIconWhite : AccountBoxIcon}
                     alt="Account box icon"
@@ -1342,9 +1369,9 @@ export default function EditProfilePage() {
                 <h2
                   className={`${
                     darkMode ? "text-white" : "text-[#053749]"
-                  } font-[Montserrat] text-[16px] font-bold`}
+                  } font-[Montserrat] text-[24px] font-bold`}
                 >
-                  Image profile
+                  {pageContent["edit-profile-image-title"]}
                 </h2>
               </div>
 
@@ -1361,16 +1388,16 @@ export default function EditProfilePage() {
             </div>
 
             <div className="flex flex-col gap-4 w-1/2">
-              <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-2 items-start">
                 <h1
-                  className={`font-[Montserrat] text-[24px] not-italic font-normal leading-[29px] ${
+                  className={`font-[Montserrat] text-[48px] not-italic font-normal leading-[29px] ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Welcome!
+                  {pageContent["edit-profile-welcome"]}
                 </h1>
-                <div className="flex items-start gap-[6px]">
-                  <div className="relative w-[24px] h-[24px]">
+                <div className="flex items-start gap-[6px] py-6">
+                  <div className="relative w-[48px] h-[48px]">
                     <Image
                       src={
                         darkMode ? AccountCircleIconWhite : AccountCircleIcon
@@ -1384,7 +1411,7 @@ export default function EditProfilePage() {
                   <span
                     className={`text-start ${
                       darkMode ? "text-white" : "text-[#053749]"
-                    } font-[Montserrat] text-[20px] font-extrabold`}
+                    } font-[Montserrat] text-[24px] font-extrabold`}
                   >
                     {username}
                   </span>
@@ -1397,11 +1424,11 @@ export default function EditProfilePage() {
                   darkMode
                     ? "bg-capx-light-bg text-[#053749]"
                     : "bg-[#053749] text-[#F6F6F6]"
-                } font-[Montserrat] text-[12px] not-italic font-extrabold leading-[normal] mb-0`}
+                } font-[Montserrat] text-[24px] not-italic font-extrabold leading-[normal] mb-0`}
                 imageUrl={darkMode ? ChangeCircleIconWhite : ChangeCircleIcon}
                 imageAlt="Change circle icon"
-                imageWidth={20}
-                imageHeight={20}
+                imageWidth={24}
+                imageHeight={24}
               />
 
               {showAvatarPopup && (
@@ -1415,7 +1442,7 @@ export default function EditProfilePage() {
                 <BaseButton
                   onClick={handleWikidataClick}
                   label={pageContent["edit-profile-use-wikidata"]}
-                  customClass={`w-full flex justify-between items-center px-[13px] py-[6px] rounded-[4px] font-[Montserrat] text-[12px] appearance-none mb-0 pb-[6px] ${
+                  customClass={`w-full flex justify-between items-center px-[13px] py-[6px] rounded-[4px] font-[Montserrat] text-[24px] appearance-none mb-0 pb-[6px] ${
                     darkMode
                       ? "bg-transparent border-white text-white opacity-50 placeholder-gray-400"
                       : "border-[#053749] text-[#829BA4]"
@@ -1430,39 +1457,38 @@ export default function EditProfilePage() {
                       : CheckIcon
                   }
                   imageAlt="Check icon"
-                  imageWidth={20}
-                  imageHeight={20}
+                  imageWidth={24}
+                  imageHeight={24}
                 />
                 <span
-                  className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                  className={`text-[20px] font-[Montserrat] not-italic font-normal leading-normal ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  I consent displaying my Wikidata item image on CapX profile
-                  (if existent).
+                  {pageContent["edit-profile-consent-wikidata"]}
                 </span>
                 <div className="flex flex-col gap-6 mt-0 w-full">
                   <BaseButton
                     onClick={handleSubmit}
                     label={pageContent["edit-profile-save"]}
-                    customClass="w-full flex items-center px-[13px] py-[6px] pb-[6px] bg-[#851970] text-white rounded-md py-3 font-bold mb-0"
+                    customClass="w-full flex items-center text-[24px] px-[13px] py-[6px] pb-[6px] bg-[#851970] text-white rounded-md py-3 font-bold mb-0"
                     imageUrl={UploadIcon}
                     imageAlt="Upload icon"
-                    imageWidth={20}
-                    imageHeight={20}
+                    imageWidth={24}
+                    imageHeight={24}
                   />
                   <BaseButton
                     onClick={() => router.back()}
                     label={pageContent["edit-profile-cancel"]}
-                    customClass={`w-full flex items-center px-[13px] py-[6px] pb-[6px] border border-[#053749] text-[#053749] rounded-md py-3 font-bold mb-0 ${
+                    customClass={`w-full flex items-center text-[24px] px-[13px] py-[6px] pb-[6px] border border-[#053749] text-[#053749] rounded-md py-3 font-bold mb-0 ${
                       darkMode
                         ? "bg-transparent text-[#F6F6F6] border-[#F6F6F6] border-[2px]"
                         : "bg-[#F6F6F6] border-[#053749] text-[#053749]"
                     }`}
                     imageUrl={darkMode ? CancelIconWhite : CancelIcon}
                     imageAlt="Cancel icon"
-                    imageWidth={20}
-                    imageHeight={20}
+                    imageWidth={24}
+                    imageHeight={24}
                   />
                 </div>
               </div>
@@ -1470,23 +1496,23 @@ export default function EditProfilePage() {
           </div>
 
           {/* Header */}
-          <div className="flex flex-col gap-[10px] mt-2">
-            <div className="flex flex-row gap-2 mt-4">
-              <div className="relative w-[20px] h-[20px]">
+          <div className="flex flex-col gap-6 mt-2">
+            <div className="flex flex-row gap-2 mt-4 items-center">
+              <div className="relative w-[48px] h-[48px]">
                 <Image
                   src={darkMode ? PersonIconWhite : PersonIcon}
                   alt="Person icon"
                   fill
-                  style={{ objectFit: "cover" }}
+                  style={{ objectFit: "contain" }}
                 />
               </div>
               <div className="flex flex-row gap-1 items-center">
                 <h2
-                  className={`font-[Montserrat] text-[14px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Mini bio
+                  {pageContent["edit-profile-mini-bio"]}
                 </h2>
               </div>
             </div>
@@ -1497,7 +1523,7 @@ export default function EditProfilePage() {
                   setFormData({ ...formData, about: e.target.value })
                 }
                 placeholder="Write a short description about yourself."
-                className={`w-full font-[Montserrat] text-[13px] not-italic font-normal leading-[normal] p-2 bg-transparent resize-none min-h-[100px] rounded-[4px] border-[1px] border-[solid] border-[#053749] px-[4px] ${
+                className={`w-full font-[Montserrat] text-[24px] not-italic font-normal leading-[normal] p-2 bg-transparent resize-none min-h-[100px] rounded-[4px] border-[1px] border-[solid] border-[#053749] px-[4px] ${
                   darkMode
                     ? "text-white placeholder-gray-400"
                     : "text-[#053749] placeholder-[#829BA4]"
@@ -1505,12 +1531,11 @@ export default function EditProfilePage() {
               />
             </div>
             <span
-              className={`font-[Montserrat] text-[12px] not-italic font-normal leading-[15px] ${
+              className={`font-[Montserrat] text-[20px] not-italic font-normal leading-normal mb-6 ${
                 darkMode ? "text-white" : "text-[#053749]"
               }`}
             >
-              Select skills you already have from the Capacity Directory. Try to
-              choose the most specific ones.{" "}
+              {pageContent["edit-profile-select-skills"]}
             </span>
           </div>
 
@@ -1522,15 +1547,15 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? NeurologyIconWhite : NeurologyIcon}
                   alt="Neurology icon"
-                  width={20}
-                  height={20}
+                  width={48}
+                  height={48}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[14px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Known capacities
+                  {pageContent["body-profile-section-title-known-capacity"]}
                 </h2>
               </div>
               <div
@@ -1546,11 +1571,11 @@ export default function EditProfilePage() {
                     <BaseButton
                       onClick={() => handleRemoveCapacity("known", index)}
                       label={getCapacityName(capacity)}
-                      customClass="rounded-[4px] border-[1px] border-[solid] border-[var(--Links-light-link,#0070B9)] flex p-[4px] pb-[4px] justify-center items-center gap-[4px] font-[Montserrat] text-[12px] not-italic font-normal leading-[normal]"
+                      customClass="rounded-[4px] border-[1px] border-[solid] border-[var(--Links-light-link,#0070B9)] flex p-[4px] pb-[4px] justify-center items-center gap-[4px] font-[Montserrat] text-[24px] not-italic font-normal leading-[normal]"
                       imageUrl={CloseIcon}
                       imageAlt="Close icon"
-                      imageWidth={16}
-                      imageHeight={16}
+                      imageWidth={24}
+                      imageHeight={24}
                     />
                   </div>
                 ))}
@@ -1558,23 +1583,22 @@ export default function EditProfilePage() {
               <BaseButton
                 onClick={() => handleAddCapacity("known")}
                 label={pageContent["edit-profile-add-capacities"]}
-                customClass={`w-full flex ${
+                customClass={`w-1/4 flex ${
                   darkMode
                     ? "bg-capx-light-box-bg text-[#04222F]"
                     : "bg-[#053749] text-white"
-                } rounded-md py-2 font-[Montserrat] text-[12px] not-italic font-extrabold leading-[normal] mb-0 pb-[6px] px-[13px] py-[6px] items-center gap-[4px]`}
+                } rounded-md py-2 font-[Montserrat] text-[24px] not-italic font-extrabold leading-[normal] mb-0 pb-[6px] px-[13px] py-[6px] items-center gap-[4px]`}
                 imageUrl={darkMode ? AddIconDark : AddIcon}
                 imageAlt="Add capacity"
-                imageWidth={20}
-                imageHeight={20}
+                imageWidth={24}
+                imageHeight={24}
               />
               <span
-                className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                className={`text-[20px] font-[Montserrat] not-italic font-normal leading-normal ${
                   darkMode ? "text-white" : "text-[#053749]"
                 }`}
               >
-                Select skills you already have from the Capacity Directory. Try
-                to choose the most specific ones.
+                {pageContent["body-profile-section-title-known-capacity"]}
               </span>
             </div>
 
@@ -1584,15 +1608,15 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? EmojiIconWhite : EmojiIcon}
                   alt="Available capacities icon"
-                  width={20}
-                  height={20}
+                  width={48}
+                  height={48}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[14px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Available capacities
+                  {pageContent["body-profile-section-title-available-capacity"]}
                 </h2>
               </div>
               <div
@@ -1608,11 +1632,11 @@ export default function EditProfilePage() {
                     <BaseButton
                       onClick={() => handleRemoveCapacity("available", index)}
                       label={getCapacityName(capacity)}
-                      customClass="rounded-[4px] border-[1px] border-[solid] border-[var(--Links-light-link,#0070B9)] flex p-[4px] pb-[4px] justify-center items-center gap-[4px] font-[Montserrat] text-[12px] not-italic font-normal leading-[normal]"
+                      customClass="rounded-[4px] border-[1px] border-[solid] border-[var(--Links-light-link,#0070B9)] flex p-[4px] pb-[4px] justify-center items-center gap-[4px] font-[Montserrat] text-[24px] not-italic font-normal leading-[normal]"
                       imageUrl={CloseIcon}
                       imageAlt="Close icon"
-                      imageWidth={16}
-                      imageHeight={16}
+                      imageWidth={24}
+                      imageHeight={24}
                     />
                   </div>
                 ))}
@@ -1620,23 +1644,22 @@ export default function EditProfilePage() {
               <BaseButton
                 onClick={() => handleAddCapacity("available")}
                 label={pageContent["edit-profile-add-capacities"]}
-                customClass={`w-full flex ${
+                customClass={`w-1/4 flex ${
                   darkMode
                     ? "bg-capx-light-box-bg text-[#04222F]"
                     : "bg-[#053749] text-white"
-                } rounded-md py-2 font-[Montserrat] text-[12px] not-italic font-extrabold leading-[normal] mb-0 pb-[6px] px-[13px] py-[6px] items-center gap-[4px]`}
+                } rounded-md py-2 font-[Montserrat] text-[24px] not-italic font-extrabold leading-[normal] mb-0 pb-[6px] px-[13px] py-[6px] items-center gap-[4px]`}
                 imageUrl={darkMode ? AddIconDark : AddIcon}
                 imageAlt="Add capacity"
-                imageWidth={20}
-                imageHeight={20}
+                imageWidth={24}
+                imageHeight={24}
               />
               <span
-                className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                className={`text-[20px] font-[Montserrat] not-italic font-normal leading-normal ${
                   darkMode ? "text-white" : "text-[#053749]"
                 }`}
               >
-                From your known capacities, choose those you are available to
-                share.
+                {pageContent["edit-profile-available-capacities"]}
               </span>
             </div>
 
@@ -1646,21 +1669,21 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? TargetIconWhite : TargetIcon}
                   alt="Wanted capacities icon"
-                  width={20}
-                  height={20}
+                  width={48}
+                  height={48}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[14px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Wanted capacities
+                  {pageContent["body-profile-section-title-wanted-capacity"]}
                 </h2>
               </div>
               <div
                 className={`flex flex-wrap gap-2 rounded-[4px] ${
                   darkMode ? "bg-[#04222F]" : "bg-[#EFEFEF]"
-                } flex w-full px-[4px] py-[6px] items-start gap-[12px]`}
+                } flex w-full px-[4px] py-[6px] items-start gap-4`}
               >
                 {formData?.skills_wanted?.map((capacity, index) => (
                   <div
@@ -1670,11 +1693,11 @@ export default function EditProfilePage() {
                     <BaseButton
                       onClick={() => handleRemoveCapacity("wanted", index)}
                       label={getCapacityName(capacity)}
-                      customClass="rounded-[4px] border-[1px] border-[solid] border-[var(--Links-light-link,#0070B9)] flex p-[4px] pb-[4px] justify-center items-center gap-[4px] font-[Montserrat] text-[12px] not-italic font-normal leading-[normal]"
+                      customClass="rounded-[4px] border-[1px] border-[solid] border-[var(--Links-light-link,#0070B9)] flex p-[4px] pb-[4px] justify-center items-center gap-[4px] font-[Montserrat] text-[24px] not-italic font-normal leading-[normal]"
                       imageUrl={CloseIcon}
                       imageAlt="Close icon"
-                      imageWidth={16}
-                      imageHeight={16}
+                      imageWidth={24}
+                      imageHeight={24}
                     />
                   </div>
                 ))}
@@ -1682,23 +1705,22 @@ export default function EditProfilePage() {
               <BaseButton
                 onClick={() => handleAddCapacity("wanted")}
                 label={pageContent["edit-profile-add-capacities"]}
-                customClass={`w-full flex ${
+                customClass={`w-1/4 flex ${
                   darkMode
                     ? "bg-capx-light-box-bg text-[#04222F]"
                     : "bg-[#053749] text-white"
-                } rounded-md py-2 font-[Montserrat] text-[12px] not-italic font-extrabold leading-[normal] mb-0 pb-[6px] px-[13px] py-[6px] items-center gap-[4px]`}
+                } rounded-md py-2 font-[Montserrat] text-[24px] not-italic font-extrabold leading-[normal] mb-0 pb-[6px] px-[13px] py-[6px] items-center gap-[4px]`}
                 imageUrl={darkMode ? AddIconDark : AddIcon}
                 imageAlt="Add capacity"
-                imageWidth={20}
-                imageHeight={20}
+                imageWidth={24}
+                imageHeight={24}
               />
               <span
-                className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                className={`text-[20px] font-[Montserrat] not-italic font-normal leading-normal ${
                   darkMode ? "text-white" : "text-[#053749]"
                 }`}
               >
-                Select skills you are willing to learn from the Capacity
-                Directory. Try to choose the most specific ones.
+                {pageContent["edit-profile-wanted-capacities"]}
               </span>
             </div>
 
@@ -1708,15 +1730,15 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? LanguageIconWhite : LanguageIcon}
                   alt="Language icon"
-                  width={20}
-                  height={20}
+                  width={48}
+                  height={48}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[14px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Languages
+                  {pageContent["body-profile-languages-title"]}
                 </h2>
               </div>
 
@@ -1729,7 +1751,7 @@ export default function EditProfilePage() {
                       darkMode ? "bg-capx-dark-bg" : "bg-[#EFEFEF]"
                     }`}
                   >
-                    <span className="font-[Montserrat] text-[12px]">
+                    <span className="font-[Montserrat] text-[24px]">
                       {languages[lang.id]}
                     </span>
                     <select
@@ -1745,19 +1767,33 @@ export default function EditProfilePage() {
                           language: newLanguages,
                         });
                       }}
-                      className={`ml-2 p-1 rounded border ${
+                      className={`ml-2 p-1 rounded border text-[24px] ${
                         darkMode
                           ? "bg-transparent border-white text-white"
                           : "border-[#053749] text-[#829BA4]"
                       }`}
                     >
-                      <option value="0">Not proficient</option>
-                      <option value="1">Basic</option>
-                      <option value="2">Intermediate</option>
-                      <option value="3">Advanced</option>
-                      <option value="4">Almost native</option>
-                      <option value="5">Professional proficiency</option>
-                      <option value="n">Native</option>
+                      <option value="0">
+                        {pageContent["profiency-level-not-proficient"]}
+                      </option>
+                      <option value="1">
+                        {pageContent["profiency-level-basic"]}
+                      </option>
+                      <option value="2">
+                        {pageContent["profiency-level-intermediate"]}
+                      </option>
+                      <option value="3">
+                        {pageContent["profiency-level-advanced"]}
+                      </option>
+                      <option value="4">
+                        {pageContent["profiency-level-almost-native"]}
+                      </option>
+                      <option value="5">
+                        {pageContent["profiency-level-professional"]}
+                      </option>
+                      <option value="n">
+                        {pageContent["profiency-level-native"]}
+                      </option>
                     </select>
                     <button
                       onClick={() => handleRemoveLanguage(index)}
@@ -1766,8 +1802,8 @@ export default function EditProfilePage() {
                       <Image
                         src={darkMode ? CloseIconWhite : CloseIcon}
                         alt="Remove language"
-                        width={16}
-                        height={16}
+                        width={24}
+                        height={24}
                       />
                     </button>
                   </div>
@@ -1789,13 +1825,15 @@ export default function EditProfilePage() {
                       });
                     }
                   }}
-                  className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[12px] appearance-none ${
+                  className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[24px] appearance-none ${
                     darkMode
                       ? "bg-transparent border-white text-white opacity-50"
                       : "border-[#053749] text-[#829BA4]"
                   } border`}
                 >
-                  <option value="">Add language...</option>
+                  <option value="">
+                    {pageContent["edit-profile-add-language"]}
+                  </option>
                   {Object.entries(languages).map(([id, name]) => (
                     <option key={id} value={id}>
                       {name}
@@ -1806,8 +1844,8 @@ export default function EditProfilePage() {
                   <Image
                     src={darkMode ? ArrowDownIconWhite : ArrowDownIcon}
                     alt="Select"
-                    width={20}
-                    height={20}
+                    width={24}
+                    height={24}
                   />
                 </div>
               </div>
@@ -1819,15 +1857,15 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? WikiIconWhite : WikiIcon}
                   alt="Alternative account icon"
-                  width={20}
-                  height={20}
+                  width={48}
+                  height={48}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[12px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Alternative Wikimedia Account
+                  {pageContent["body-profile-box-title-alt-wiki-acc"]}
                 </h2>
               </div>
               <input
@@ -1840,18 +1878,18 @@ export default function EditProfilePage() {
                     wiki_alt: e.target.value,
                   })
                 }
-                className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[12px] ${
+                className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[24px] ${
                   darkMode
                     ? "bg-transparent border-white text-white opacity-50 placeholder-gray-400"
                     : "border-[#053749] text-[#829BA4]"
                 } border`}
               />
               <span
-                className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                className={`text-[24px] font-[Montserrat] not-italic font-normal leading-normal ${
                   darkMode ? "text-white" : "text-[#053749]"
                 }`}
               >
-                Share another Wikimedia username if you have one.
+                {pageContent["edit-profile-share-username"]}
               </span>
             </div>
 
@@ -1861,15 +1899,15 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? AffiliationIconWhite : AffiliationIcon}
                   alt="Affiliation icon"
-                  width={20}
-                  height={20}
+                  width={48}
+                  height={48}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[12px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Affiliation
+                  {pageContent["body-profile-section-title-affiliation"]}
                 </h2>
               </div>
               <div className="relative">
@@ -1881,13 +1919,15 @@ export default function EditProfilePage() {
                       affiliation: e.target.value ? [e.target.value] : [],
                     })
                   }
-                  className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[12px] appearance-none ${
+                  className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[24px] appearance-none ${
                     darkMode
                       ? "bg-transparent border-white text-white opacity-50 placeholder-gray-400"
                       : "border-[#053749] text-[#829BA4]"
                   } border`}
                 >
-                  <option value="">{pageContent["edit-profile-insert-item"]}</option>
+                  <option value="">
+                    {pageContent["edit-profile-insert-item"]}
+                  </option>
                   {Object.entries(affiliations).map(([id, name]) => (
                     <option key={id} value={id}>
                       {name}
@@ -1898,17 +1938,17 @@ export default function EditProfilePage() {
                   <Image
                     src={darkMode ? ArrowDownIconWhite : ArrowDownIcon}
                     alt="Select"
-                    width={20}
-                    height={20}
+                    width={24}
+                    height={24}
                   />
                 </div>
               </div>
               <span
-                className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                className={`text-[24px] font-[Montserrat] not-italic font-normal leading-normal ${
                   darkMode ? "text-white" : "text-[#053749]"
                 }`}
               >
-                Select your organization from the dropdown menu.
+                {pageContent["body-profile-section-affiliation-dropdown-menu"]}
               </span>
             </div>
 
@@ -1918,15 +1958,15 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? TerritoryIconWhite : TerritoryIcon}
                   alt="Territory icon"
-                  width={20}
-                  height={20}
+                  width={48}
+                  height={48}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[14px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Territory
+                  {pageContent["body-profile-section-title-territory"]}
                 </h2>
               </div>
               <div className="relative">
@@ -1938,13 +1978,15 @@ export default function EditProfilePage() {
                       territory: e.target.value ? [e.target.value] : [],
                     })
                   }
-                  className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[12px] appearance-none ${
+                  className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[24px] appearance-none ${
                     darkMode
                       ? "bg-transparent border-white text-white opacity-50 placeholder-gray-400"
                       : "border-[#053749] text-[#829BA4]"
                   } border`}
                 >
-                  <option value="">{pageContent["edit-profile-insert-item"]}</option>
+                  <option value="">
+                    {pageContent["edit-profile-insert-item"]}
+                  </option>
                   {Object.entries(territories).map(([id, name]) => (
                     <option key={id} value={id}>
                       {name}
@@ -1955,17 +1997,17 @@ export default function EditProfilePage() {
                   <Image
                     src={darkMode ? ArrowDownIconWhite : ArrowDownIcon}
                     alt="Select"
-                    width={20}
-                    height={20}
+                    width={24}
+                    height={24}
                   />
                 </div>
               </div>
               <span
-                className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                className={`text-[24px] font-[Montserrat] not-italic font-normal leading-normal ${
                   darkMode ? "text-white" : "text-[#053749]"
                 }`}
               >
-                Inform your geographic location by region or country.
+                {pageContent["edit-profile-territory"]}
               </span>
             </div>
 
@@ -1975,15 +2017,15 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? BarCodeIconWhite : BarCodeIcon}
                   alt="Wikidata item icon"
-                  width={20}
-                  height={20}
+                  width={24}
+                  height={24}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[14px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Wikidata Item
+                  {pageContent["edit-profile-wikidata-item"]}
                 </h2>
               </div>
               <div className="flex items-center gap-2 py-[6px] ">
@@ -2002,7 +2044,7 @@ export default function EditProfilePage() {
                 <BaseButton
                   onClick={handleWikidataClick}
                   label={pageContent["edit-profile-use-wikidata"]}
-                  customClass={`w-full flex justify-between items-center px-[13px] py-[6px] rounded-[4px] font-[Montserrat] text-[12px] appearance-none mb-0 pb-[6px] ${
+                  customClass={`w-full flex justify-between items-center px-[13px] py-[6px] rounded-[4px] font-[Montserrat] text-[24px] appearance-none mb-0 pb-[6px] ${
                     darkMode
                       ? "bg-transparent border-white text-white opacity-50 placeholder-gray-400"
                       : "border-[#053749] text-[#829BA4]"
@@ -2017,17 +2059,16 @@ export default function EditProfilePage() {
                       : CheckIcon
                   }
                   imageAlt="Check icon"
-                  imageWidth={20}
-                  imageHeight={20}
+                  imageWidth={24}
+                  imageHeight={24}
                 />
               </div>
               <span
-                className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                className={`text-[24px] font-[Montserrat] not-italic font-normal leading-normal ${
                   darkMode ? "text-white" : "text-[#053749]"
                 }`}
               >
-                I consent displaying my Wikidata item on CapX profile (if
-                existent).
+                {pageContent["edit-profile-consent-wikidata-item"]}
               </span>
             </div>
 
@@ -2037,15 +2078,15 @@ export default function EditProfilePage() {
                 <Image
                   src={darkMode ? WikiIconWhite : WikiIcon}
                   alt="Wikimedia projects icon"
-                  width={20}
-                  height={20}
+                  width={48}
+                  height={48}
                 />
                 <h2
-                  className={`font-[Montserrat] text-[14px] font-bold ${
+                  className={`font-[Montserrat] text-[24px] font-bold ${
                     darkMode ? "text-white" : "text-[#053749]"
                   }`}
                 >
-                  Wikimedia Projects
+                  {pageContent["body-profile-wikimedia-projects-title"]}
                 </h2>
               </div>
               <div className="relative">
@@ -2062,15 +2103,21 @@ export default function EditProfilePage() {
                       });
                     }
                   }}
-                  className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[12px] appearance-none ${
+                  className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[24px] appearance-none ${
                     darkMode
                       ? "bg-transparent border-white text-white opacity-50 placeholder-gray-400"
                       : "border-[#053749] text-[#829BA4]"
                   } border`}
                 >
-                  <option value="">{pageContent["edit-profile-insert-project"]}</option>
+                  <option value="">
+                    {pageContent["edit-profile-insert-project"]}
+                  </option>
                   {Object.entries(wikimediaProjects).map(([id, name]) => (
-                    <option key={id} value={id}>
+                    <option
+                      key={id}
+                      value={id}
+                      className="font-[Montserrat] text-[24px]"
+                    >
                       {name}
                     </option>
                   ))}
@@ -2079,13 +2126,12 @@ export default function EditProfilePage() {
                   <Image
                     src={darkMode ? ArrowDownIconWhite : ArrowDownIcon}
                     alt="Select"
-                    width={20}
-                    height={20}
+                    width={24}
+                    height={24}
                   />
                 </div>
               </div>
 
-              {/* Renderiza os campos de seleção adicionais para projetos */}
               {formData.wikimedia_project?.slice(1).map((project, index) => (
                 <div key={index} className="relative">
                   <select
@@ -2100,13 +2146,15 @@ export default function EditProfilePage() {
                         wikimedia_project: newProjects,
                       });
                     }}
-                    className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[12px] appearance-none ${
+                    className={`w-full px-4 py-2 rounded-[4px] font-[Montserrat] text-[24px] appearance-none ${
                       darkMode
                         ? "bg-transparent border-white text-white opacity-50 placeholder-gray-400"
                         : "border-[#053749] text-[#829BA4]"
                     } border`}
                   >
-                    <option value="">{pageContent["edit-profile-insert-project"]}</option>
+                    <option value="">
+                      {pageContent["edit-profile-insert-project"]}
+                    </option>
                     {Object.entries(wikimediaProjects).map(([id, name]) => (
                       <option key={id} value={id}>
                         {name}
@@ -2117,8 +2165,8 @@ export default function EditProfilePage() {
                     <Image
                       src={darkMode ? ArrowDownIconWhite : ArrowDownIcon}
                       alt="Select"
-                      width={20}
-                      height={20}
+                      width={24}
+                      height={24}
                     />
                   </div>
                 </div>
@@ -2127,18 +2175,18 @@ export default function EditProfilePage() {
               <BaseButton
                 onClick={handleAddProject}
                 label={pageContent["edit-profile-add-more-projects"]}
-                customClass={`w-full flex ${
+                customClass={`w-1/4 flex ${
                   darkMode
                     ? "bg-capx-light-box-bg text-[#04222F]"
                     : "bg-[#053749] text-white"
-                } rounded-md py-2 font-[Montserrat] text-[12px] not-italic font-extrabold leading-[normal] mb-0 pb-[6px] px-[13px] py-[6px] items-center gap-[4px]`}
+                } rounded-md py-2 font-[Montserrat] text-[24px] not-italic font-extrabold leading-[normal] mb-0 pb-[6px] px-[13px] py-[6px] items-center gap-[4px]`}
                 imageUrl={darkMode ? AddIconDark : AddIcon}
                 imageAlt="Add project"
-                imageWidth={20}
-                imageHeight={20}
+                imageWidth={24}
+                imageHeight={24}
               />
               <span
-                className={`text-[12px] font-[Montserrat] not-italic font-normal leading-[15px] ${
+                className={`text-[24px] font-[Montserrat] not-italic font-normal leading-normal ${
                   darkMode ? "text-white" : "text-[#053749]"
                 }`}
               >
@@ -2148,28 +2196,28 @@ export default function EditProfilePage() {
           </div>
 
           {/* Action Buttons */}
-          <div className="flex flex-row gap-[10px] mt-0">
+          <div className="flex flex-row gap-6 mt-6">
             <BaseButton
               onClick={handleSubmit}
               label={pageContent["edit-profile-save"]}
-              customClass="w-full flex items-center px-[13px] py-[6px] pb-[6px] bg-[#851970] text-white rounded-md py-3 font-bold mb-0"
+              customClass="w-full flex items-center text-[24px] px-[13px] py-[6px] pb-[6px] bg-[#851970] text-white rounded-md py-3 font-bold mb-0"
               imageUrl={UploadIcon}
               imageAlt="Upload icon"
-              imageWidth={20}
-              imageHeight={20}
+              imageWidth={24}
+              imageHeight={24}
             />
             <BaseButton
               onClick={() => router.back()}
               label={pageContent["edit-profile-cancel"]}
-              customClass={`w-full flex items-center px-[13px] py-[6px] pb-[6px] border ${
+              customClass={`w-full flex items-center text-[24px] px-[13px] py-[6px] pb-[6px] border ${
                 darkMode
                   ? "border-white text-white"
                   : "border-[#053749] text-[#053749]"
               } rounded-md py-3 font-bold mb-0`}
               imageUrl={darkMode ? CancelIconWhite : CancelIcon}
               imageAlt="Cancel icon"
-              imageWidth={20}
-              imageHeight={20}
+              imageWidth={24}
+              imageHeight={24}
             />
           </div>
         </div>

--- a/src/components/CapacitiesList.tsx
+++ b/src/components/CapacitiesList.tsx
@@ -107,7 +107,7 @@ export function CapacitiesList({
                   : title ===
                     pageContent["body-profile-wanted-capacities-title"]
                   ? "bg-[#D43831] text-[24px] text-white"
-                  : "bg-[#EFEFEF]"
+                  : "bg-[#05A300]" //TODO: Verify why available capacities are not green and return this fallback color to #EFEFEF
               }`}
             >
               <p className={customClass + " !text-[24px] font-normal"}>

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import { useTheme } from "@/contexts/ThemeContext";
+import CapxLogo from "@/public/static/images/capx_detailed_logo.svg";
+
+export default function LoadingState() {
+  const { darkMode } = useTheme();
+
+  return (
+    <div
+      className={`flex items-center justify-center min-h-screen ${
+        darkMode ? "bg-capx-dark-box-bg" : "bg-capx-light-bg"
+      }`}
+    >
+      <div className="relative w-16 h-16">
+        <Image
+          src={CapxLogo}
+          alt="CAPX Logo"
+          className="animate-pulse-fade"
+          width={64}
+          height={64}
+        />
+        <style jsx global>{`
+          @keyframes pulseFade {
+            0% {
+              opacity: 0.3;
+            }
+            50% {
+              opacity: 1;
+            }
+            100% {
+              opacity: 0.3;
+            }
+          }
+          .animate-pulse-fade {
+            animation: pulseFade 2s ease-in-out infinite;
+          }
+        `}</style>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -43,7 +43,10 @@ const Popup = ({
     <div className={customClass}>
       {isOpen && (
         <>
-          <div className="fixed inset-0 bg-black bg-opacity-50 z-40" onClick={onOverlayClick} />
+          <div
+            className="fixed inset-0 bg-black bg-opacity-50 z-40"
+            onClick={onOverlayClick}
+          />
           <div
             className={`fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 
             w-[90%] md:w-[880px] xl:w-[1024px]
@@ -75,12 +78,14 @@ const Popup = ({
                 darkMode ? "bg-[#005B3F]" : "bg-white"
               }`}
             >
-              {image && (<Image
-                src={image}
-                alt="Popup Illustration"
-                className="w-full max-w-[300px] h-auto mb-8"
-                priority
-              />)}
+              {image && (
+                <Image
+                  src={image}
+                  alt="Popup Illustration"
+                  className="w-full max-w-[300px] h-auto mb-8"
+                  priority
+                />
+              )}
 
               <h2
                 className={`text-xl text-center font-extrabold mb-8 font-[Montserrat] ${
@@ -90,7 +95,7 @@ const Popup = ({
                 {title}
               </h2>
 
-               {/* Show children components */}
+              {/* Show children components */}
               <div className="mb-8">{children}</div>
 
               <div className="flex flex-row gap-4 w-full">

--- a/src/hooks/useOrganizationProfile.ts
+++ b/src/hooks/useOrganizationProfile.ts
@@ -6,13 +6,16 @@ import { Organization } from "@/types/organization";
 
 export function useOrganization(token?: string, forceManager = false) {
   const [organization, setOrganization] = useState<Organization | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true); // Iniciar como true
   const [error, setError] = useState<string | null>(null);
   const [isOrgManager, setIsOrgManager] = useState(forceManager);
   const [organizationId, setOrganizationId] = useState<number | null>(null);
 
   const fetchUserProfile = useCallback(async () => {
-    if (!token) return;
+    if (!token) {
+      setIsLoading(false);
+      return;
+    }
 
     try {
       setIsLoading(true);
@@ -30,9 +33,18 @@ export function useOrganization(token?: string, forceManager = false) {
         )?.is_manager[0];
         setOrganizationId(managedOrgId);
         setIsOrgManager(true);
+
+        if (managedOrgId) {
+          const orgData = await organizationProfileService.getOrganizationById(
+            token,
+            managedOrgId
+          );
+          setOrganization(orgData);
+        }
       } else {
         setIsOrgManager(false);
         setOrganizationId(null);
+        setOrganization(null);
       }
     } catch (err) {
       setError(
@@ -40,6 +52,7 @@ export function useOrganization(token?: string, forceManager = false) {
       );
       setIsOrgManager(false);
       setOrganizationId(null);
+      setOrganization(null);
     } finally {
       setIsLoading(false);
     }
@@ -113,6 +126,10 @@ export function useOrganization(token?: string, forceManager = false) {
     },
     [token, organizationId]
   );
+  /*   const refetch = useCallback(() => {
+    setIsLoading(true); // Garantir que loading seja true ao refetch
+    return fetchUserProfile();
+  }, [fetchUserProfile]); */
 
   return {
     organization,
@@ -122,7 +139,7 @@ export function useOrganization(token?: string, forceManager = false) {
     isOrgManager,
     organizationId,
     fetchUserProfile,
-    fetchOrganizationById,
     updateOrganization,
+    fetchOrganizationById,
   };
 }


### PR DESCRIPTION
# PR: Fix Organization Profile Loading State and Navigation

## Description

This PR addresses issues with loading states and navigation between organization profile pages, specifically focusing on the transition between `/organization_profile` and `/organization_profile/edit`.

## Changes

### Loading State Implementation
- Fixed loading state handling in `useOrganization` hook to properly manage loading states during transitions
- Removed unnecessary loading checks in `EditOrganizationProfilePage`
- Unified loading state checks across organization profile pages

### Navigation Flow
- Fixed redirection logic for non-manager users
- Improved state management during page transitions
- Ensured consistent loading state display during navigation

## Testing
- Verified loading state appears when navigating from organization profile to edit page
- Confirmed proper redirection for non-manager users
- Tested loading states in both light and dark modes
