### PR TITLE
Fix organization profile multiple orgs view

### DIFF
--- a/src/app/(auth)/organization_profile/[id]/edit/page.tsx
+++ b/src/app/(auth)/organization_profile/[id]/edit/page.tsx
@@ -89,8 +89,7 @@ export default function EditOrganizationProfilePage() {
   } = useDocument(token);
 
   // Organization setters
-  const hookId = "main-hook";
-  console.log(`[${hookId}] Chamando useOrganization com organizationId:`, organizationId);
+
 
   const {
     organization,
@@ -102,7 +101,6 @@ export default function EditOrganizationProfilePage() {
     updateOrganization,
   } = useOrganization(token, Number(organizationId));
 
-  console.log(`[${hookId}] Resultado de isOrgManager:`, isOrgManager);
 
   // Projects setters
   const {

--- a/src/app/(auth)/organization_profile/[id]/edit/page.tsx
+++ b/src/app/(auth)/organization_profile/[id]/edit/page.tsx
@@ -89,14 +89,20 @@ export default function EditOrganizationProfilePage() {
   } = useDocument(token);
 
   // Organization setters
+  const hookId = "main-hook";
+  console.log(`[${hookId}] Chamando useOrganization com organizationId:`, organizationId);
+
   const {
     organization,
     organizations,
     isLoading: isOrganizationLoading,
     error: organizationError,
-    updateOrganization,
     isOrgManager,
-  } = useOrganization(token);
+    refetch,
+    updateOrganization,
+  } = useOrganization(token, Number(organizationId));
+
+  console.log(`[${hookId}] Resultado de isOrgManager:`, isOrgManager);
 
   // Projects setters
   const {
@@ -120,6 +126,8 @@ export default function EditOrganizationProfilePage() {
   const [editedProjects, setEditedProjects] = useState<{
     [key: number]: boolean;
   }>({});
+
+
 
   // Effect to load projects
   useEffect(() => {
@@ -269,14 +277,14 @@ export default function EditOrganizationProfilePage() {
         wanted_capacities: organization.wanted_capacities || [],
       });
 
-      // Inicializa os dados dos eventos
+      // Initialize events data
       if (organization.events && organization.events.length > 0) {
         if (events) {
           setEventsData(events);
         }
       }
 
-      // Inicializa os dados dos projetos
+      // Initialize projects data
       if (organization.tag_diff && organization.tag_diff.length > 0) {
         const fetchTagsData = async () => {
           try {
@@ -304,7 +312,7 @@ export default function EditOrganizationProfilePage() {
         fetchTagsData();
       }
 
-      // Inicializa os dados dos documentos
+      // Initialize documents data
       if (
         organization.documents &&
         organization.documents.length > 0 &&
@@ -317,7 +325,7 @@ export default function EditOrganizationProfilePage() {
         setDocumentsData(existingDocuments);
       }
 
-      // Inicializa os dados de contato
+      // Initialize contacts data
       if (organization) {
         setContactsData({
           id: organization.id?.toString() || "",
@@ -555,7 +563,7 @@ export default function EditOrganizationProfilePage() {
       await updateOrganization(updatedFormData as Partial<OrganizationType>);
       await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      // Atualiza o redirecionamento para incluir o ID da organização
+      // Update the redirection to include the organization ID
       router.push(`/organization_profile/${organizationId}`);
     } catch (error) {
       console.error("Error processing form:", error);
@@ -678,17 +686,17 @@ export default function EditOrganizationProfilePage() {
       type_of_location: event.type_of_location || "virtual",
     };
 
-    // Primeiro atualiza no backend se for um evento existente
+    // First update in the backend if it's an existing event
     if (event.id > 0 && token) {
       try {
         await updateEvent(event.id, updatedEvent);
       } catch (error) {
         console.error("Error updating event:", error);
-        return; // Se falhar a atualização, não atualiza o estado local
+        return; // If the update fails, do not update the local state
       }
     }
 
-    // Depois atualiza o estado local
+    // Then update the local state
     setEventsData((prev) => {
       const updated = [...prev];
       updated[index] = updatedEvent;

--- a/src/app/(auth)/organization_profile/[id]/page.tsx
+++ b/src/app/(auth)/organization_profile/[id]/page.tsx
@@ -51,8 +51,6 @@ export default function OrganizationProfilePage() {
     refetch,
   } = useOrganization(token, organizationId);
 
-  console.log(organizations)
-  console.log(isOrgManager)
   const organization = organizations.find(org => org.id === organizationId);
 
   const {
@@ -336,7 +334,6 @@ export default function OrganizationProfilePage() {
                   TODO
                 </p> */}
 
-                  {console.log(isOrgManager)}
                 {isOrgManager && (
                   <BaseButton
                     onClick={() => router.push(`/organization_profile/${organizationId}/edit`)}

--- a/src/app/(auth)/organization_profile/[id]/page.tsx
+++ b/src/app/(auth)/organization_profile/[id]/page.tsx
@@ -49,8 +49,10 @@ export default function OrganizationProfilePage() {
     error,
     isOrgManager,
     refetch,
-  } = useOrganization(token);
+  } = useOrganization(token, organizationId);
 
+  console.log(organizations)
+  console.log(isOrgManager)
   const organization = organizations.find(org => org.id === organizationId);
 
   const {
@@ -334,6 +336,7 @@ export default function OrganizationProfilePage() {
                   TODO
                 </p> */}
 
+                  {console.log(isOrgManager)}
                 {isOrgManager && (
                   <BaseButton
                     onClick={() => router.push(`/organization_profile/${organizationId}/edit`)}

--- a/src/hooks/useOrganizationProfile.ts
+++ b/src/hooks/useOrganizationProfile.ts
@@ -33,11 +33,10 @@ export function useOrganization(token?: string, specificOrgId?: number) {
             : []
         );
 
-        console.log("IDs de organizações gerenciadas:", managedIds);
         setManagedOrganizationIds(managedIds);
         setIsPermissionsLoaded(true);
       } catch (err) {
-        console.error("Erro ao buscar perfil do usuário:", err);
+        console.error("Error fetching user profile:", err);
         setManagedOrganizationIds([]);
         setIsPermissionsLoaded(true);
       }
@@ -50,10 +49,10 @@ export function useOrganization(token?: string, specificOrgId?: number) {
           );
           setOrganizations([orgData]);
         } catch (err) {
-          console.error(`Erro ao buscar organização ${specificOrgId}:`, err);
+          console.error(`Error fetching organization ${specificOrgId}:`, err);
           setOrganizations([]);
           setError(
-            `Erro ao buscar organização: ${err.message || "Erro desconhecido"}`
+            `Error fetching organization: ${err.message || "Unknown error"}`
           );
         }
       } else if (managedOrganizationIds.length > 0) {
@@ -83,20 +82,11 @@ export function useOrganization(token?: string, specificOrgId?: number) {
     fetchData();
   }, [fetchData]);
 
+  // Check if the user is a manager of the specific organization
   const isOrgManager =
     isPermissionsLoaded && specificOrgId
       ? managedOrganizationIds.includes(Number(specificOrgId))
       : false;
-
-  console.log("specificOrgId:", specificOrgId);
-  console.log("specificOrgId como número:", Number(specificOrgId));
-  console.log("managedOrganizationIds:", managedOrganizationIds);
-  console.log("isPermissionsLoaded:", isPermissionsLoaded);
-  console.log(
-    "Verificação includes:",
-    managedOrganizationIds.includes(Number(specificOrgId))
-  );
-  console.log("isOrgManager final:", isOrgManager);
 
   return {
     organization: organizations[0],


### PR DESCRIPTION
# Fix organization profile permissions and visibility

## Overview

This PR addresses an issue where users were unable to view organization profiles for organizations they are not managers of. Additionally, it fixes a permission issue where the edit button was incorrectly displayed for all organizations, regardless of whether the user was a manager or not.

## Changes

### 1. Fixed permission checking in `useOrganization` hook

- Added proper verification to check if a user is a manager of a specific organization
- Fixed the `isOrgManager` flag to only return `true` when the user is a manager of the specific organization being viewed
- Added a new `isPermissionsLoaded` state to ensure permissions are fully loaded before making authorization decisions

```typescript
// Before - incorrect permission check
isOrgManager: managedOrganizationIds.length > 0,

// After - correct permission check
const isOrgManager = isPermissionsLoaded && specificOrgId 
  ? managedOrganizationIds.includes(Number(specificOrgId))
  : false;
```

### 2. Improved data loading in organization profile page

- Enhanced the organization data fetching to work for all organizations, not just managed ones
- Ensured organization data is properly displayed regardless of manager status

### 3. UI improvements for non-manager view

- Added a clear "View mode" message when viewing an organization the user is not a manager of
- Disabled edit functionality for non-managers

## Testing

- Verified that users can now view organization profiles for organizations they are not managers of
- Confirmed that the edit button only appears for organizations the user is a manager of
- Verified that all organization data (projects, events, capacities, etc.) is properly displayed
