### PR TITLE
Add GitHub Actions workflow for automatic release on version change

### DIFF
--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate releases when the version in `package.json` changes. The workflow monitors the `dev` branch and ensures the updated version is merged into the `main` branch.

### New GitHub Actions Workflow:
* `.github/workflows/release-on-version-change.yml`: Added a workflow named "Release on Version Change" that triggers on pushes to the `dev` branch when `package.json` is modified. The workflow:
  - Extracts the version from `package.json`.
  - Configures Git for the bot.
  - Merges the `dev` branch into `main` with a release commit message containing the version.