### PR TITLE
fix statistic data

### DIFF
--- a/src/app/api/statistics/route.ts
+++ b/src/app/api/statistics/route.ts
@@ -7,16 +7,16 @@ export async function GET() {
     const response = await axios.get(backendUrl, {
       headers: {
         'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Pragma': 'no-cache',
-        'Expires': '0'
-      }
+        Pragma: 'no-cache',
+        Expires: '0',
+      },
     });
     return NextResponse.json(response.data, {
       headers: {
         'Cache-Control': 'no-cache, no-store, must-revalidate',
-        'Pragma': 'no-cache',
-        'Expires': '0'
-      }
+        Pragma: 'no-cache',
+        Expires: '0',
+      },
     });
   } catch (error) {
     console.error('Error fetching statistics from backend:', error);
@@ -36,9 +36,9 @@ export async function GET() {
         status: 500,
         headers: {
           'Cache-Control': 'no-cache, no-store, must-revalidate',
-          'Pragma': 'no-cache',
-          'Expires': '0'
-        }
+          Pragma: 'no-cache',
+          Expires: '0',
+        },
       }
     );
   }

--- a/src/hooks/useStatistics.ts
+++ b/src/hooks/useStatistics.ts
@@ -18,8 +18,8 @@ export const useStatistics = () => {
               headers: {
                 Authorization: `Token ${session.user.token}`,
                 'Cache-Control': 'no-cache',
-                'Pragma': 'no-cache'
-              }
+                Pragma: 'no-cache',
+              },
             }
           : undefined;
         const statisticsData = await statisticsService.fetchStatistics(config);


### PR DESCRIPTION
Adicionado cache-busting através de headers HTTP para garantir que os dados sejam sempre buscados diretamente do backend sem necessidade de rebuild.