### PR TITLE
Fix children and grandchildren capacities visualization

### DIFF
--- a/src/app/capacities_visualization/components/D3TreeVisualization.tsx
+++ b/src/app/capacities_visualization/components/D3TreeVisualization.tsx
@@ -229,8 +229,8 @@ export default function D3TreeVisualization({
   };
 
   // Utility function to capitalize first letter
-  function capitalizeFirst(str: string) {
-    if (!str) return '';
+  function capitalizeFirst(str: string | undefined | null) {
+    if (!str || typeof str !== 'string') return '';
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
 

--- a/src/hooks/useCapacityList.ts
+++ b/src/hooks/useCapacityList.ts
@@ -154,7 +154,13 @@ export function useCapacityList(token?: string, language: string = 'en') {
           });
 
           const capacityData = await Promise.all(
-            Object.entries(response).map(async ([code, name]) => {
+            Object.entries(response).map(async ([code, nameOrResponse]) => {
+              // Extract name from response (API returns { name, wd_code, metabase_code })
+              const name =
+                typeof nameOrResponse === 'string'
+                  ? nameOrResponse
+                  : (nameOrResponse as any)?.name || `Capacity ${code}`;
+
               // Verificar se já temos os filhos desta capacidade no cache
               if (!globalCache.childrenCapacities[code]) {
                 const childrenResponse = await capacityService.fetchCapacitiesByType(code, {


### PR DESCRIPTION
## Summary
  Fixed missing child and grandchild capacity data in the capacities visualization page.

  ## Changes
  - **Fixed missing descriptions**: Child and grandchild capacities now display their
  descriptions correctly
  - **Fixed missing names**: Child and grandchild capacities now show their actual names instead
   of "Capacity [id]"
  - **Refactored to use hooks**: Replaced direct service calls with `useCapacityList` hook for
  better caching and consistency
  - **Added data validation**: Enhanced type safety to prevent errors when data is missing

  ## Technical Details
  - Updated `CapacitiesTreeVisualization.tsx` to fetch child and grandchild data using hooks
  - Fixed `useCapacityList.ts` to correctly extract names from API response objects
  - Added fallback values for missing names to prevent `charAt is not a function` errors
  - Improved `capitalizeFirst` function with proper type checking

  ## Files Changed
  - `src/app/capacities_visualization/components/CapacitiesTreeVisualization.tsx`
  - `src/app/capacities_visualization/components/D3TreeVisualization.tsx`
  - `src/hooks/useCapacityList.ts`

  ## Test Plan
  - [x] Navigate to `/capacities_visualization`
  - [x] Expand root capacities to view children
  - [x] Expand child capacities to view grandchildren
  - [x] Verify names and descriptions are displayed correctly
  - [x] Confirm no console errors