### PR TITLE
Fix profile carousel redirecting to wrong user profile

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -96,6 +96,10 @@ export const userService = {
       params.append('name', queryParams.filters.name);
     }
 
+    if (queryParams?.filters?.username) {
+      params.append('username', queryParams.filters.username);
+    }
+
     if (queryParams?.ordering) {
       params.append('ordering', queryParams.ordering);
     }


### PR DESCRIPTION
Fixed bug where clicking "View Profile" on any user in the profile recommendation carousel would always load the same user profile instead of the selected one. The issue was caused by the username filter not being passed to the API request in `userService.fetchAllUsers`.