### PR TITLE
421 text logo isnt very visible in dark themed background

### DIFF
--- a/src/app/(auth)/feed/components/ProfileCard.tsx
+++ b/src/app/(auth)/feed/components/ProfileCard.tsx
@@ -223,9 +223,11 @@ export const ProfileCard = ({
 
               {/* Profile Image */}
               <div className="flex flex-col items-center mb-6">
-                <div className={`relative w-[100px] h-[100px] md:w-[200px] md:h-[200px] ${
-                  darkMode ? 'bg-[#EFEFEF]' : ''
-                } rounded-[4px]`}>
+                <div
+                  className={`relative w-[100px] h-[100px] md:w-[200px] md:h-[200px] ${
+                    darkMode ? 'bg-[#EFEFEF]' : ''
+                  } rounded-[4px]`}
+                >
                   <Image
                     src={profileImageUrl || defaultAvatar}
                     alt={


### PR DESCRIPTION
Improve card layout by adding a proper 'green' color on 'sharer' label and also add background to the images to improve contrast.