### PR TITLE
Refactor: Territory API Integration

### DIFF
--- a/src/__tests__/components/CapacityFeedCard.test.tsx
+++ b/src/__tests__/components/CapacityFeedCard.test.tsx
@@ -140,7 +140,11 @@ jest.mock('next-auth/react', () => ({
 
 jest.mock('@/hooks/useTerritories', () => ({
   useTerritories: () => ({
-    territories: {
+    territories: [
+      { id: 1, territory_name: 'Brazil', territory_acronym: 'LAC', parent_territory: [22] },
+      { id: 2, territory_name: 'Argentina', territory_acronym: 'LAC', parent_territory: [22] },
+    ],
+    territoriesMap: {
       '1': 'Brazil',
       '2': 'Argentina',
     },

--- a/src/app/(auth)/data_analytics_dashboard/components/AnalyticsDashboard.tsx
+++ b/src/app/(auth)/data_analytics_dashboard/components/AnalyticsDashboard.tsx
@@ -231,7 +231,14 @@ export default function AnalyticsDashboardPage() {
   const [visibleLanguagesCount, setVisibleLanguagesCount] = useState(8);
   const [mapViewMode, setMapViewMode] = useState<'users' | 'languages' | 'capacities'>('users');
 
-  const sortedTerritories = getTopItems(territories, data?.territory_user_counts, 8);
+  const sortedTerritories = territories
+    .map(t => ({
+      id: t.id,
+      name: t.territory_name,
+      count: data?.territory_user_counts?.[String(t.id)] ?? 0,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 8);
   const sortedLanguages = getTopItems(languages, data?.language_user_counts).filter(
     lang => lang.count > 0
   );
@@ -328,148 +335,148 @@ export default function AnalyticsDashboardPage() {
 
       {/* Language Dropdown */}
       {(mapViewMode === 'users' || mapViewMode === 'languages') && (
-      <div className="flex flex-col px-4 w-full gap-2 mt-[40px]">
-        <DropdownHeader
-          icon={LanguageIcon}
-          iconWhite={LanguageIconWhite}
-          title={pageContent['analytics-bashboard-languages-title']}
-          isOpen={openLanguages}
-          onToggle={() => setOpenLanguages(!openLanguages)}
-          darkMode={darkMode}
-        />
+        <div className="flex flex-col px-4 w-full gap-2 mt-[40px]">
+          <DropdownHeader
+            icon={LanguageIcon}
+            iconWhite={LanguageIconWhite}
+            title={pageContent['analytics-bashboard-languages-title']}
+            isOpen={openLanguages}
+            onToggle={() => setOpenLanguages(!openLanguages)}
+            darkMode={darkMode}
+          />
 
-        {openLanguages && (
-          <div
-            className={`mt-8 gap-4 ${
-              darkMode ? 'bg-[#053749] text-white' : 'bg-white text-[#053749]'
-            } overflow-hidden`}
-          >
-            {visibleLanguages.map(language => (
-              <div key={language.id} className="flex flex-row justify-between md:items-center">
-                <div
-                  className={`font-[Montserrat] text-[12px] md:text-[24px] font-bold ${
-                    darkMode ? 'text-white' : 'text-[#053749]'
+          {openLanguages && (
+            <div
+              className={`mt-8 gap-4 ${
+                darkMode ? 'bg-[#053749] text-white' : 'bg-white text-[#053749]'
+              } overflow-hidden`}
+            >
+              {visibleLanguages.map(language => (
+                <div key={language.id} className="flex flex-row justify-between md:items-center">
+                  <div
+                    className={`font-[Montserrat] text-[12px] md:text-[24px] font-bold ${
+                      darkMode ? 'text-white' : 'text-[#053749]'
+                    }`}
+                  >
+                    {language.name}
+                  </div>
+                  <div
+                    className={`font-[Montserrat] text-[12px] md:text-[24px] mb-4 md:mr-[80px] flex items-center gap-1 ${
+                      darkMode ? 'text-white' : 'text-[#053749]'
+                    }`}
+                  >
+                    {formatNumber(language.count ?? 0)}{' '}
+                    {pageContent['analytics-bashboard-territory-users']}
+                  </div>
+                </div>
+              ))}
+
+              {visibleLanguagesCount < sortedLanguages.length && (
+                <button
+                  onClick={handleLoadMoreLanguages}
+                  className={`w-full md:w-auto mx-auto flex items-center justify-center gap-2 px-4 md:py-2 border-2 border-[#053749] rounded-lg text-[#053749] text-[12px] md:text-[24px] font-bold hover:bg-[#EFEFEF] transition ${
+                    darkMode
+                      ? 'text-white border-white hover:bg-[#0A4C5A]'
+                      : 'text-[#053749] border-[#053749]'
                   }`}
                 >
-                  {language.name}
-                </div>
-                <div
-                  className={`font-[Montserrat] text-[12px] md:text-[24px] mb-4 md:mr-[80px] flex items-center gap-1 ${
-                    darkMode ? 'text-white' : 'text-[#053749]'
-                  }`}
-                >
-                  {formatNumber(language.count ?? 0)}{' '}
-                  {pageContent['analytics-bashboard-territory-users']}
-                </div>
-              </div>
-            ))}
-
-            {visibleLanguagesCount < sortedLanguages.length && (
-              <button
-                onClick={handleLoadMoreLanguages}
-                className={`w-full md:w-auto mx-auto flex items-center justify-center gap-2 px-4 md:py-2 border-2 border-[#053749] rounded-lg text-[#053749] text-[12px] md:text-[24px] font-bold hover:bg-[#EFEFEF] transition ${
-                  darkMode
-                    ? 'text-white border-white hover:bg-[#0A4C5A]'
-                    : 'text-[#053749] border-[#053749]'
-                }`}
-              >
-                {pageContent['analytics-bashboard-capacities-load-more']}
-                <span className="text-xl">+</span>
-              </button>
-            )}
-          </div>
-        )}
-      </div>
+                  {pageContent['analytics-bashboard-capacities-load-more']}
+                  <span className="text-xl">+</span>
+                </button>
+              )}
+            </div>
+          )}
+        </div>
       )}
 
       {/* Territories Dropdown */}
       {mapViewMode === 'users' && (
-      <div className="flex flex-col px-4 w-full gap-2 mt-[40px]">
-        <DropdownHeader
-          icon={TerritoryIcon}
-          iconWhite={TerritoryIconWhite}
-          title={pageContent['analytics-bashboard-territory-title']}
-          isOpen={openTerritories}
-          onToggle={() => setOpenTerritories(!openTerritories)}
-          darkMode={darkMode}
-        />
+        <div className="flex flex-col px-4 w-full gap-2 mt-[40px]">
+          <DropdownHeader
+            icon={TerritoryIcon}
+            iconWhite={TerritoryIconWhite}
+            title={pageContent['analytics-bashboard-territory-title']}
+            isOpen={openTerritories}
+            onToggle={() => setOpenTerritories(!openTerritories)}
+            darkMode={darkMode}
+          />
 
-        {openTerritories && (
-          <div
-            className={`mt-8 gap-4 ${
-              darkMode ? 'bg-[#053749] text-white' : 'bg-white text-[#053749]'
-            } overflow-hidden`}
-          >
-            {sortedTerritories.map(territory => (
-              <div
-                className="flex flex-col md:flex-row md:justify-between md:items-center"
-                key={territory.id}
-              >
+          {openTerritories && (
+            <div
+              className={`mt-8 gap-4 ${
+                darkMode ? 'bg-[#053749] text-white' : 'bg-white text-[#053749]'
+              } overflow-hidden`}
+            >
+              {sortedTerritories.map(territory => (
                 <div
-                  className={`font-[Montserrat] text-[12px] md:text-[24px] font-bold ${
-                    darkMode ? 'text-white' : 'text-[#053749]'
-                  }`}
+                  className="flex flex-col md:flex-row md:justify-between md:items-center"
+                  key={territory.id}
                 >
-                  {territory.name}
+                  <div
+                    className={`font-[Montserrat] text-[12px] md:text-[24px] font-bold ${
+                      darkMode ? 'text-white' : 'text-[#053749]'
+                    }`}
+                  >
+                    {territory.name}
+                  </div>
+                  <div
+                    className={`font-[Montserrat] text-[12px] md:text-[24px] mb-4 mr-[80px] md:mb-4 ${
+                      darkMode ? 'text-white' : 'text-[#053749]'
+                    } flex items-center gap-1`}
+                  >
+                    {formatNumber(territory.count ?? 0)}{' '}
+                    {pageContent['analytics-bashboard-territory-users']}
+                  </div>
                 </div>
-                <div
-                  className={`font-[Montserrat] text-[12px] md:text-[24px] mb-4 mr-[80px] md:mb-4 ${
-                    darkMode ? 'text-white' : 'text-[#053749]'
-                  } flex items-center gap-1`}
-                >
-                  {formatNumber(territory.count ?? 0)}{' '}
-                  {pageContent['analytics-bashboard-territory-users']}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
+              ))}
+            </div>
+          )}
+        </div>
       )}
 
       {/* Capacties Dropdown */}
       {(mapViewMode === 'users' || mapViewMode === 'capacities') && (
-      <div className="flex flex-col px-4 w-full gap-2 mt-[40px]">
-        <DropdownHeader
-          icon={CapxIcon}
-          iconWhite={capxIconWhite}
-          title={pageContent['analytics-bashboard-capacities-title']}
-          isOpen={openCapacities}
-          onToggle={() => setOpenCapacities(!openCapacities)}
-          darkMode={darkMode}
-        />
+        <div className="flex flex-col px-4 w-full gap-2 mt-[40px]">
+          <DropdownHeader
+            icon={CapxIcon}
+            iconWhite={capxIconWhite}
+            title={pageContent['analytics-bashboard-capacities-title']}
+            isOpen={openCapacities}
+            onToggle={() => setOpenCapacities(!openCapacities)}
+            darkMode={darkMode}
+          />
 
-        {openCapacities && (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
-            {availableCount &&
-              Object.keys(availableCount).map(id => {
-                const skillId = Number(id);
-                const metadata = SKILL_METADATA[skillId];
+          {openCapacities && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+              {availableCount &&
+                Object.keys(availableCount).map(id => {
+                  const skillId = Number(id);
+                  const metadata = SKILL_METADATA[skillId];
 
-                return (
-                  <CapacityCardAnalytics
-                    key={`${metadata?.key}-${skillId}`}
-                    open={openCapacities}
-                    title={metadata ? pageContent[metadata.key] : ''}
-                    icon={metadata?.icon}
-                    headerColor={metadata?.headerColor || '#EFEFEF'}
-                    darkMode={darkMode}
-                    cards={[
-                      {
-                        titleCard: pageContent['analytics-bashboard-capacities-card-learners'],
-                        value: wantedCount?.[id] || 0,
-                      },
-                      {
-                        titleCard: pageContent['analytics-bashboard-capacities-card-sharers'],
-                        value: availableCount?.[id] || 0,
-                      },
-                    ]}
-                  />
-                );
-              })}
-          </div>
-        )}
-      </div>
+                  return (
+                    <CapacityCardAnalytics
+                      key={`${metadata?.key}-${skillId}`}
+                      open={openCapacities}
+                      title={metadata ? pageContent[metadata.key] : ''}
+                      icon={metadata?.icon}
+                      headerColor={metadata?.headerColor || '#EFEFEF'}
+                      darkMode={darkMode}
+                      cards={[
+                        {
+                          titleCard: pageContent['analytics-bashboard-capacities-card-learners'],
+                          value: wantedCount?.[id] || 0,
+                        },
+                        {
+                          titleCard: pageContent['analytics-bashboard-capacities-card-sharers'],
+                          value: availableCount?.[id] || 0,
+                        },
+                      ]}
+                    />
+                  );
+                })}
+            </div>
+          )}
+        </div>
       )}
     </section>
   );

--- a/src/app/(auth)/data_analytics_dashboard/components/SVGWorldMap.tsx
+++ b/src/app/(auth)/data_analytics_dashboard/components/SVGWorldMap.tsx
@@ -33,7 +33,7 @@ interface SVGWorldMapProps {
   languageUserCounts?: Record<string, number>;
   languages?: Record<string, string>;
   territoryUserCounts?: Record<string, number>;
-  territories?: Record<string, string>;
+  territories?: { id: number; territory_acronym: string }[];
   capacities?: Record<string, string>;
   languagesByTerritory?: AggregatedLanguageData;
   capacitiesByTerritory?: AggregatedCapacityData;
@@ -101,9 +101,9 @@ export default function SVGWorldMap({
 
   const wikimediaTerritories = useMemo(() => getWikimediaTerritories(pageContent), [pageContent]);
 
-  // Create API territory ID to Wikimedia ID mapping (uses fallback if territories unavailable)
+  // Create API territory ID to Wikimedia ID mapping using territory_acronym from API
   const apiTerritoryToWikimediaMap = useMemo(() => {
-    return buildApiTerritoryToWikimediaMap(territories);
+    return buildApiTerritoryToWikimediaMap(territories ?? []);
   }, [territories]);
 
   // Map API territories to Wikimedia territory counts
@@ -114,7 +114,6 @@ export default function SVGWorldMap({
       return counts;
     }
 
-    // Use the apiTerritoryToWikimediaMap which has fallback logic built in
     Object.entries(territoryUserCounts).forEach(([id, count]) => {
       const wikimediaId = apiTerritoryToWikimediaMap[id];
       if (wikimediaId) {
@@ -207,7 +206,9 @@ export default function SVGWorldMap({
         values = Object.values(languageCountsByWikimediaTerritory);
         break;
       case 'capacities':
-        values = Object.values(capacityCountsByWikimediaTerritory).map(c => c.total);
+        values = Object.values(capacityCountsByWikimediaTerritory).map(c =>
+          selectedCapacityType === 'all' ? c.total : c[selectedCapacityType] || 0
+        );
         break;
       default:
         values = Object.values(wikimediaTerritoryUserCounts);
@@ -219,6 +220,7 @@ export default function SVGWorldMap({
     wikimediaTerritoryUserCounts,
     languageCountsByWikimediaTerritory,
     capacityCountsByWikimediaTerritory,
+    selectedCapacityType,
   ]);
 
   // Get total users - use prop if available, otherwise calculate from territories
@@ -371,8 +373,11 @@ export default function SVGWorldMap({
       switch (viewMode) {
         case 'languages':
           return languageCountsByWikimediaTerritory[territory.id] || 0;
-        case 'capacities':
-          return capacityCountsByWikimediaTerritory[territory.id]?.total || 0;
+        case 'capacities': {
+          const cap = capacityCountsByWikimediaTerritory[territory.id];
+          if (!cap) return 0;
+          return selectedCapacityType === 'all' ? cap.total : cap[selectedCapacityType] || 0;
+        }
         default:
           return wikimediaTerritoryUserCounts[territory.id] || 0;
       }
@@ -382,6 +387,7 @@ export default function SVGWorldMap({
       wikimediaTerritoryUserCounts,
       languageCountsByWikimediaTerritory,
       capacityCountsByWikimediaTerritory,
+      selectedCapacityType,
     ]
   );
 
@@ -631,7 +637,10 @@ export default function SVGWorldMap({
       {/* View Mode Toggle */}
       <div className="mb-4 flex flex-wrap gap-2">
         <button
-          onClick={() => { setViewMode('users'); onViewModeChange?.('users'); }}
+          onClick={() => {
+            setViewMode('users');
+            onViewModeChange?.('users');
+          }}
           className={`px-4 py-2 rounded-lg font-[Montserrat] text-sm font-semibold transition-colors ${
             viewMode === 'users' ? 'bg-capx-primary-blue text-white' : buttonStyle
           }`}
@@ -639,7 +648,10 @@ export default function SVGWorldMap({
           {pageContent['analytics-map-filter-users'] || 'Wikimedians'}
         </button>
         <button
-          onClick={() => { setViewMode('languages'); onViewModeChange?.('languages'); }}
+          onClick={() => {
+            setViewMode('languages');
+            onViewModeChange?.('languages');
+          }}
           className={`px-4 py-2 rounded-lg font-[Montserrat] text-sm font-semibold transition-colors ${
             viewMode === 'languages' ? 'bg-capx-primary-green text-white' : buttonStyle
           }`}
@@ -647,7 +659,10 @@ export default function SVGWorldMap({
           {pageContent['analytics-bashboard-languages-title'] || 'Languages'}
         </button>
         <button
-          onClick={() => { setViewMode('capacities'); onViewModeChange?.('capacities'); }}
+          onClick={() => {
+            setViewMode('capacities');
+            onViewModeChange?.('capacities');
+          }}
           className={`px-4 py-2 rounded-lg font-[Montserrat] text-sm font-semibold transition-colors ${
             viewMode === 'capacities' ? 'bg-capx-secondary-purple text-white' : buttonStyle
           }`}
@@ -953,43 +968,44 @@ export default function SVGWorldMap({
                   )}
 
                   {/* Top Capacities */}
-                  {viewMode !== 'languages' && (topCapacities.length > 0 || isCapacitiesLoading) && (
-                    <div className="mt-3">
-                      <p
-                        className={`font-[Montserrat] text-xs font-semibold mb-1 ${darkMode ? 'text-white/70' : 'text-gray-500'}`}
-                      >
-                        {pageContent['analytics-map-top-capacities'] || 'Top Capacities'}:
-                      </p>
-                      <div className="flex flex-wrap gap-1">
-                        {isCapacitiesLoading ? (
-                          <span
-                            className={`text-xs px-2 py-0.5 rounded animate-pulse ${darkMode ? 'bg-capx-dark-box-bg text-white/50' : 'bg-gray-100 text-gray-400'}`}
-                          >
-                            {pageContent['analytics-map-loading-capacities'] ||
-                              `Loading capacities in `}
-                            {currentLanguage}…
-                          </span>
-                        ) : (
-                          topCapacities.map(cap => (
+                  {viewMode !== 'languages' &&
+                    (topCapacities.length > 0 || isCapacitiesLoading) && (
+                      <div className="mt-3">
+                        <p
+                          className={`font-[Montserrat] text-xs font-semibold mb-1 ${darkMode ? 'text-white/70' : 'text-gray-500'}`}
+                        >
+                          {pageContent['analytics-map-top-capacities'] || 'Top Capacities'}:
+                        </p>
+                        <div className="flex flex-wrap gap-1">
+                          {isCapacitiesLoading ? (
                             <span
-                              key={cap.id}
-                              className={`text-xs px-2 py-0.5 rounded ${darkMode ? 'bg-capx-dark-box-bg text-white/80' : 'bg-gray-100 text-gray-700'}`}
+                              className={`text-xs px-2 py-0.5 rounded animate-pulse ${darkMode ? 'bg-capx-dark-box-bg text-white/50' : 'bg-gray-100 text-gray-400'}`}
                             >
-                              {cap.name.charAt(0).toUpperCase()}
-                              {cap.name.slice(1)} —{' '}
-                              {selectedCapacityType === 'all'
-                                ? `${pageContent['analytics-map-capacity-known'] || 'Known'}: ${cap.known} ${pageContent['analytics-map-capacity-available'] || 'Available'}: ${cap.available} ${pageContent['analytics-map-capacity-wanted'] || 'Wanted'}: ${cap.wanted}`
-                                : selectedCapacityType === 'known'
-                                  ? `${pageContent['analytics-map-capacity-known'] || 'Known'}: ${cap.known}`
-                                  : selectedCapacityType === 'available'
-                                    ? `${pageContent['analytics-map-capacity-available'] || 'Available'}: ${cap.available}`
-                                    : `${pageContent['analytics-map-capacity-wanted'] || 'Wanted'}: ${cap.wanted}`}
+                              {pageContent['analytics-map-loading-capacities'] ||
+                                `Loading capacities in `}
+                              {currentLanguage}…
                             </span>
-                          ))
-                        )}
+                          ) : (
+                            topCapacities.map(cap => (
+                              <span
+                                key={cap.id}
+                                className={`text-xs px-2 py-0.5 rounded ${darkMode ? 'bg-capx-dark-box-bg text-white/80' : 'bg-gray-100 text-gray-700'}`}
+                              >
+                                {cap.name.charAt(0).toUpperCase()}
+                                {cap.name.slice(1)} —{' '}
+                                {selectedCapacityType === 'all'
+                                  ? `${pageContent['analytics-map-capacity-known'] || 'Known'}: ${cap.known} ${pageContent['analytics-map-capacity-available'] || 'Available'}: ${cap.available} ${pageContent['analytics-map-capacity-wanted'] || 'Wanted'}: ${cap.wanted}`
+                                  : selectedCapacityType === 'known'
+                                    ? `${pageContent['analytics-map-capacity-known'] || 'Known'}: ${cap.known}`
+                                    : selectedCapacityType === 'available'
+                                      ? `${pageContent['analytics-map-capacity-available'] || 'Available'}: ${cap.available}`
+                                      : `${pageContent['analytics-map-capacity-wanted'] || 'Wanted'}: ${cap.wanted}`}
+                              </span>
+                            ))
+                          )}
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    )}
                 </>
               );
             })()}
@@ -1033,6 +1049,40 @@ export default function SVGWorldMap({
         >
           {pageContent['analytics-map-click-deselect'] || 'Click again to deselect'}
         </p>
+      )}
+
+      {/* Legend (when no territory is selected) */}
+      {!selectedTerritory && !hoveredTerritory && (
+        <div className={`mt-4 p-4 rounded-lg ${darkMode ? 'bg-capx-dark-bg' : 'bg-gray-50'}`}>
+          <h4
+            className={`font-[Montserrat] font-bold text-sm mb-2 ${darkMode ? 'text-white' : 'text-capx-dark-box-bg'}`}
+          >
+            {pageContent['analytics-map-legend-title'] || 'Legend'}
+          </h4>
+          <div className="flex items-center gap-2">
+            <span
+              className={`font-[Montserrat] text-xs ${darkMode ? 'text-white/70' : 'text-gray-600'}`}
+            >
+              0
+            </span>
+            <div
+              className="flex-1 h-4 rounded"
+              style={{
+                background: `linear-gradient(to right, ${gradientColors.light}, ${gradientColors.dark})`,
+              }}
+            />
+            <span
+              className={`font-[Montserrat] text-xs ${darkMode ? 'text-white/70' : 'text-gray-600'}`}
+            >
+              {maxCount.toLocaleString()}{' '}
+              {viewMode === 'languages' && selectedLanguageId === 'all'
+                ? pageContent['analytics-bashboard-languages-title'] || 'Languages'
+                : viewMode === 'capacities' && selectedCapacityId === 'all'
+                  ? pageContent['analytics-bashboard-capacities-title'] || 'Capacities'
+                  : pageContent['analytics-bashboard-territory-users'] || 'Wikimedians'}
+            </span>
+          </div>
+        </div>
       )}
 
       {/* Territory Grid (when no territory is selected) */}

--- a/src/app/(auth)/data_analytics_dashboard/components/wikimediaTerritories.ts
+++ b/src/app/(auth)/data_analytics_dashboard/components/wikimediaTerritories.ts
@@ -627,77 +627,32 @@ export function getColorForCountry(countryCode: string, darkMode: boolean): stri
   return darkMode ? territory.colorDark : territory.color;
 }
 
-// Fallback mapping of known API territory IDs to Wikimedia territory IDs
-// Based on actual API data: IDs 18-25 are the Wikimedia regions
-export const API_TERRITORY_ID_TO_WIKIMEDIA: Record<string, string> = {
-  '18': 'MENA', // Middle East & North Africa (MENA)
-  '19': 'SSA', // Sub-Saharan Africa (SSA)
-  '20': 'SA', // South Asia (SA)
-  '21': 'ESEAP', // East, Southeast Asia, & Pacific (ESEAP)
-  '22': 'LAC', // Latin America & Caribbean (LAC)
-  '23': 'NA', // North America (NA)
-  '24': 'NWE', // Northern & Western Europe (NWE)
-  '25': 'CEECA', // Central & Eastern Europe & Central Asia (CEECA)
+// Stable base mapping: the statistics endpoint uses these numeric IDs for Wikimedia regions.
+// This is a contract with the stats API and is always included in the final map.
+const STATISTICS_ID_TO_WIKIMEDIA: Record<string, string> = {
+  '18': 'MENA',
+  '19': 'SSA',
+  '20': 'SA',
+  '21': 'ESEAP',
+  '22': 'LAC',
+  '23': 'NA',
+  '24': 'NWE',
+  '25': 'CEECA',
 };
 
-// Build mapping from API territory to Wikimedia territory using either dynamic names or fallback
+// Build mapping from API territory ID to Wikimedia territory acronym.
+// Always starts from the stable stats mapping so IDs 18-25 are always covered.
+// API territory_acronym data is merged on top, extending the map with any additional
+// territory IDs that the stats endpoints may use.
 export function buildApiTerritoryToWikimediaMap(
-  territories: Record<string, string> | null | undefined
+  territories: { id: number; territory_acronym: string }[]
 ): Record<string, string> {
-  const map: Record<string, string> = {};
-
-  // If territories is available, use dynamic mapping based on names
-  if (territories && Object.keys(territories).length > 0) {
-    // Map that handles various naming patterns including parenthetical abbreviations
-    // e.g., "Middle East & North Africa (MENA)" or "Sub-Saharan Africa (SSA)"
-    const NORMALIZED_TERRITORY_MAP: Record<string, string> = {
-      // Full names without abbreviations
-      subsaharanafrica: 'SSA',
-      northernandwesterneurope: 'NWE',
-      eastsoutheastasiaandpacific: 'ESEAP',
-      latinamericaandcaribbean: 'LAC',
-      centralandeasterneuropeandcentralasia: 'CEECA',
-      southasia: 'SA',
-      middleeastandnorthafrica: 'MENA',
-      northamerica: 'NA',
-      // With abbreviations in parentheses (normalized)
-      subsaharanafricassa: 'SSA',
-      northernandwesterneuropenwe: 'NWE',
-      eastsoutheastasiaandpacificeseap: 'ESEAP',
-      latinamericaandcaribbeanlac: 'LAC',
-      centralandeasterneuropeandcentralasiaceeca: 'CEECA',
-      southasiasa: 'SA',
-      middleeastandnorthafricamena: 'MENA',
-      northamericana: 'NA',
-      // Just abbreviations
-      ssa: 'SSA',
-      nwe: 'NWE',
-      eseap: 'ESEAP',
-      lac: 'LAC',
-      ceeca: 'CEECA',
-      sa: 'SA',
-      mena: 'MENA',
-      na: 'NA',
-    };
-
-    Object.entries(territories).forEach(([id, name]) => {
-      const normalizedName = name
-        .toLowerCase()
-        .replace(/&/g, 'and')
-        .replace(/[^a-z0-9]/g, '')
-        .trim();
-      const wikimediaId = NORMALIZED_TERRITORY_MAP[normalizedName];
-      if (wikimediaId) {
-        map[id] = wikimediaId;
-      }
-    });
-
-    // If we found mappings, return them
-    if (Object.keys(map).length > 0) {
-      return map;
+  const apiMap = territories.reduce<Record<string, string>>((acc, t) => {
+    if (t.territory_acronym) {
+      acc[String(t.id)] = t.territory_acronym.toUpperCase();
     }
-  }
+    return acc;
+  }, {});
 
-  // Fallback to hardcoded mapping when territories data is not available or no matches found
-  return { ...API_TERRITORY_ID_TO_WIKIMEDIA };
+  return { ...STATISTICS_ID_TO_WIKIMEDIA, ...apiMap };
 }

--- a/src/app/(auth)/feed/components/ProfileCard.tsx
+++ b/src/app/(auth)/feed/components/ProfileCard.tsx
@@ -111,7 +111,7 @@ export const ProfileCard = ({
   const { data: session } = useSession();
   const token = session?.user?.token;
   const { languages: availableLanguages } = useLanguage(token);
-  const { territories: availableTerritories } = useTerritories(token);
+  const { territoriesMap: availableTerritories } = useTerritories(token);
 
   // Use custom hook for profile image loading
   const { profileImageUrl } = useProfileImage({

--- a/src/app/(auth)/feed/components/TerritorySelector.tsx
+++ b/src/app/(auth)/feed/components/TerritorySelector.tsx
@@ -1,9 +1,11 @@
-import { SelectList } from './Selector';
 import TerritoryIcon from '@/public/static/images/territory.svg';
 import TerritoryIconWhite from '@/public/static/images/territory_white.svg';
 import { usePageContent } from '@/stores';
+import { Territory } from '@/types/territory';
+import { SelectList } from './Selector';
+
 interface TerritorySelectorProps {
-  territories: Record<string, string>;
+  territories: Territory[];
   selectedTerritories: string[];
   onSelectTerritory: (TerritoryId: string) => void;
   placeholder?: string;
@@ -14,37 +16,18 @@ export function TerritorySelector({
   selectedTerritories,
   onSelectTerritory,
   placeholder,
-}: TerritorySelectorProps) {
+}: Readonly<TerritorySelectorProps>) {
   const pageContent = usePageContent();
 
-  // Region ids to order first
-  const priorityTerritoryIds = ['18', '19', '20', '21', '22', '23', '24', '25'];
-
-  const territoriesList = Object.entries(territories)
-    .map(([id, name]) => ({
-      id,
-      name,
+  const territoriesList = territories
+    .map(t => ({
+      id: String(t.id),
+      name: t.territory_name,
+      isTopLevel: t.parent_territory.length === 0,
     }))
     .sort((a, b) => {
-      const aIsPriority = priorityTerritoryIds.includes(a.id);
-      const bIsPriority = priorityTerritoryIds.includes(b.id);
-
-      // If both are regions, order them
-      if (aIsPriority && bIsPriority) {
-        return a.name.localeCompare(b.name);
-      }
-
-      // If only A is region, it comes first
-      if (aIsPriority && !bIsPriority) {
-        return -1;
-      }
-
-      // If B is region, B comes first
-      if (!aIsPriority && bIsPriority) {
-        return 1;
-      }
-
-      // If none is region, order
+      if (a.isTopLevel && !b.isTopLevel) return -1;
+      if (!a.isTopLevel && b.isTopLevel) return 1;
       return a.name.localeCompare(b.name);
     });
 

--- a/src/app/(auth)/home/components/AnalyticsCallToActionSection.tsx
+++ b/src/app/(auth)/home/components/AnalyticsCallToActionSection.tsx
@@ -24,7 +24,7 @@ export default function AnalyticsCallToActionSection() {
   const isMobile = useIsMobile();
   const darkMode = useDarkMode();
   const { data, isLoading } = useStatistics();
-  const { territories, loading: territoriesLoading } = useTerritories(token);
+  const { territoriesMap: territories, loading: territoriesLoading } = useTerritories(token);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isVisible, setIsVisible] = useState(true);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/src/app/(auth)/organization_profile/[id]/page.tsx
+++ b/src/app/(auth)/organization_profile/[id]/page.tsx
@@ -17,7 +17,7 @@ export default function OrganizationProfilePage() {
   const token = session?.user?.token;
   const capacityCache = useCapacityStore();
   const { isLoadingTranslations } = capacityCache;
-  const { territories } = useTerritories(token);
+  const { territoriesMap: territories } = useTerritories(token);
 
   const params = useParams();
   const organizationId = Number(params?.id);
@@ -85,7 +85,7 @@ export default function OrganizationProfilePage() {
       token={token}
       isOrgManager={isOrgManager}
       getCapacityName={getCapacityName}
-      territories={territories || {}}
+      territories={territories}
     />
   );
 }

--- a/src/app/(auth)/organization_profile/components/OrganizationProfileEditMainWrapper.tsx
+++ b/src/app/(auth)/organization_profile/components/OrganizationProfileEditMainWrapper.tsx
@@ -180,7 +180,7 @@ export default function EditOrganizationProfilePage() {
   const { avatars } = useAvatars();
   const capacityCache = useCapacityStore();
   const { isLoadingTranslations } = capacityCache;
-  const { territories } = useTerritories(token);
+  const { territoriesMap: territories } = useTerritories(token);
 
   /* State Management*/
 
@@ -1268,7 +1268,7 @@ export default function EditOrganizationProfilePage() {
         handleEditEvent={handleEditEvent}
         handleChooseEvent={handleChooseEvent}
         handleViewAllEvents={handleViewAllEvents}
-        territories={territories || {}}
+        territories={territories}
         organizationId={Number(organizationId)}
       />
 

--- a/src/app/(auth)/profile/components/ProfilePage.tsx
+++ b/src/app/(auth)/profile/components/ProfilePage.tsx
@@ -64,7 +64,7 @@ export default function ProfilePage({ isSameUser, profile }: Readonly<ProfilePag
   const currentLanguage = useCurrentLanguage();
   const { languages } = useLanguage(token, currentLanguage);
   const { affiliations } = useAffiliation(token);
-  const { territories } = useTerritories(token);
+  const { territoriesMap: territories } = useTerritories(token);
   const { wikimediaProjects, wikimediaProjectImages } = useWikimediaProject(
     token,
     profile?.wikimedia_project || []

--- a/src/app/(auth)/profile/edit/components/ProfileEditMainWrapper.tsx
+++ b/src/app/(auth)/profile/edit/components/ProfileEditMainWrapper.tsx
@@ -132,7 +132,7 @@ export default function EditProfilePage() {
     refetch,
     deleteProfile,
   } = useProfile(token, userId);
-  const { territories } = useTerritories(token);
+  const { territoriesMap: territories } = useTerritories(token);
   const { languages } = useLanguage(token, language);
   const { affiliations } = useAffiliation(token);
   const { wikimediaProjects, error: wikimediaProjectsError } = useWikimediaProject(token);
@@ -684,7 +684,7 @@ export default function EditProfilePage() {
     handleCancel: () => router.back(),
     formData,
     setFormData,
-    territories: territories || {},
+    territories,
     languages: languages || {},
     affiliations: affiliations || {},
     wikimediaProjects: wikimediaProjects || {},

--- a/src/app/api/territory/route.ts
+++ b/src/app/api/territory/route.ts
@@ -4,7 +4,11 @@ import { NextRequest, NextResponse } from 'next/server';
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');
   try {
-    const response = await axios.get(`${process.env.BASE_URL}/territory`, {
+    const { searchParams } = new URL(request.url);
+    const queryString = searchParams.toString();
+    const url = `${process.env.BASE_URL}/territory/${queryString ? `?${queryString}` : ''}`;
+
+    const response = await axios.get(url, {
       headers: {
         Authorization: authHeader,
       },

--- a/src/hooks/useTerritories.ts
+++ b/src/hooks/useTerritories.ts
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
-import { Territories } from '@/types/territory';
+import { useState, useEffect, useMemo } from 'react';
+import { Territory } from '@/types/territory';
 import { fetchTerritories } from '@/services/territoryService';
 
 export const useTerritories = (token: string | undefined) => {
-  const [territories, setTerritories] = useState<Territories>({});
+  const [territories, setTerritories] = useState<Territory[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -16,11 +16,11 @@ export const useTerritories = (token: string | undefined) => {
 
       try {
         const data = await fetchTerritories(token);
-        setTerritories(data || {});
+        setTerritories(data || []);
       } catch (err) {
         console.error('Error loading territories:', err);
         setError(err instanceof Error ? err.message : 'Failed to load territories');
-        setTerritories({});
+        setTerritories([]);
       } finally {
         setLoading(false);
       }
@@ -29,8 +29,19 @@ export const useTerritories = (token: string | undefined) => {
     loadTerritories();
   }, [token]);
 
+  // Derived map of id (string) → territory_name for components that need lookup by id
+  const territoriesMap = useMemo(
+    () =>
+      territories.reduce<Record<string, string>>((acc, t) => {
+        acc[String(t.id)] = t.territory_name;
+        return acc;
+      }, {}),
+    [territories]
+  );
+
   return {
     territories,
+    territoriesMap,
     loading,
     error,
   };

--- a/src/services/territoryService.ts
+++ b/src/services/territoryService.ts
@@ -1,15 +1,32 @@
 import axios from 'axios';
-import { Territories } from '@/types/territory';
+import { Territory, TerritoriesResponse } from '@/types/territory';
 
-export const fetchTerritories = async (token?: string): Promise<Territories> => {
+export const fetchTerritories = async (token?: string): Promise<Territory[]> => {
   const headers: Record<string, string> = {};
   if (token) {
     headers.Authorization = `Token ${token}`;
   }
 
-  const response = await axios.get<Territories>(`/api/list/territory/`, {
-    headers,
-  });
+  const results: Territory[] = [];
+  let nextQuery: string | null = null;
 
-  return response.data;
+  do {
+    const url = nextQuery ? `/api/territory/?${nextQuery}` : `/api/territory/`;
+
+    const response = await axios.get<TerritoriesResponse>(url, { headers });
+    results.push(...response.data.results);
+
+    // Extract only the query string from the absolute next URL so we can proxy it correctly
+    if (response.data.next) {
+      try {
+        nextQuery = new URL(response.data.next).search.replace(/^\?/, '');
+      } catch {
+        nextQuery = null;
+      }
+    } else {
+      nextQuery = null;
+    }
+  } while (nextQuery);
+
+  return results;
 };

--- a/src/types/territory.ts
+++ b/src/types/territory.ts
@@ -1,3 +1,13 @@
-export interface Territories {
-  [key: string]: string;
+export interface Territory {
+  id: number;
+  territory_name: string;
+  territory_acronym: string;
+  parent_territory: number[];
+}
+
+export interface TerritoriesResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: Territory[];
 }


### PR DESCRIPTION
Summary                                                                
                                                                         
  - Refactor territory API integration: Replaced the old                 
  /api/list/territory/ endpoint with the paginated /api/territory/ route 
  across the entire application. The service now auto-fetches all pages, 
  returning a flat Territory[] array instead of a key-value map.         
  - Updated territory types: Replaced the loose Territories dict type    
  with a proper Territory interface (id, territory_name,                 
  territory_acronym, parent_territory) and a TerritoriesResponse wrapper
  for paginated API responses.                                           
  - Improved useTerritories hook: Now returns both the raw territories
  array and a derived territoriesMap (id → name) for components that need
   fast lookups; also skips fetching when no token is available.
  - Map visualization cleanup: Removed redundant territory information   
  from SVGWorldMap info cards to reduce visual noise.                    
                    
  Test plan                                                              
                  
  - Verify territories load correctly in the feed's TerritorySelector    
  - Verify territories load correctly in profile and organization profile
   pages                                                                 
  - Verify the analytics dashboard map renders territory data with
  correct names                                                          
  - Confirm pagination works — all territories are fetched when the API
  returns a next URL                                                     
  - Confirm no regressions in CapacityFeedCard tests