### PR TITLE
fix: resolve capacity Wikidata labels and mobile modal layout

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,44 +1,44 @@
 approvedGitRepositories:
-  - "**"
+  - '**'
 
 enableScripts: true
 
 nodeLinker: node-modules
 
 packageExtensions:
-  "@chromatic-com/storybook@*":
+  '@chromatic-com/storybook@*':
     peerDependencies:
-      react: "*"
-      react-dom: "*"
+      react: '*'
+      react-dom: '*'
     peerDependenciesMeta:
       react:
         optional: true
       react-dom:
         optional: true
-  "@storybook/addon-docs@*":
+  '@storybook/addon-docs@*':
     peerDependencies:
-      "@types/react": "*"
+      '@types/react': '*'
     peerDependenciesMeta:
-      "@types/react":
+      '@types/react':
         optional: true
-  "@storybook/addon-essentials@*":
+  '@storybook/addon-essentials@*':
     peerDependencies:
-      "@types/react": "*"
+      '@types/react': '*'
     peerDependenciesMeta:
-      "@types/react":
+      '@types/react':
         optional: true
-  "@storybook/core@*":
+  '@storybook/core@*':
     peerDependencies:
-      storybook: "*"
+      storybook: '*'
     peerDependenciesMeta:
       storybook:
         optional: true
   babel-plugin-styled-components@*:
     peerDependencies:
-      "@babel/core": "*"
+      '@babel/core': '*'
   styled-components@*:
     peerDependencies:
-      "@babel/core": "*"
+      '@babel/core': '*'
     peerDependenciesMeta:
-      "@babel/core":
+      '@babel/core':
         optional: true

--- a/src/app/(auth)/capacity/components/CapacityListMainWrapper.tsx
+++ b/src/app/(auth)/capacity/components/CapacityListMainWrapper.tsx
@@ -53,7 +53,7 @@ const ChildCapacities = ({
   const { data: rootCapacities = [] } = useRootCapacities(language);
   const isMobile = useIsMobile();
 
-  const { getDescription, getWdCode, getMetabaseCode, getColor } = useCapacityStore();
+  const { getName, getDescription, getWdCode, getMetabaseCode, getColor } = useCapacityStore();
 
   if (isLoadingChildren) {
     return <LoadingState />;
@@ -133,7 +133,7 @@ const ChildCapacities = ({
         >
           <CapacityCard
             code={child.code}
-            name={child.name}
+            name={getName(child.code) || child.name}
             icon={child.icon}
             color={child.color}
             isExpanded={!!expandedCapacities[child.code]}

--- a/src/app/(auth)/organization_profile/components/EventsEditForm.tsx
+++ b/src/app/(auth)/organization_profile/components/EventsEditForm.tsx
@@ -105,7 +105,7 @@ OrganizationLoader.displayName = 'OrganizationLoader';
 
 // Memoize the EventsForm component to avoid unnecessary renders
 const EventsForm = memo(
-  ({ eventData, index, onChange, eventType }: EventFormItemProps) => {
+  ({ eventData, index, onChange, eventType: _eventType }: EventFormItemProps) => {
     const darkMode = useDarkMode();
     const isMobile = useIsMobile();
     const pageContent = usePageContent();

--- a/src/app/api/capacity/type/[id]/route.ts
+++ b/src/app/api/capacity/type/[id]/route.ts
@@ -1,6 +1,10 @@
 export const dynamic = 'force-dynamic';
 
-import { fetchCapacitiesWithFallback, fetchWikidata } from '@/lib/utils/capacitiesUtils';
+import {
+  fetchCapacitiesWithFallback,
+  fetchWikidata,
+  sanitizeCapacityName,
+} from '@/lib/utils/capacitiesUtils';
 import axios from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -81,7 +85,8 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       const wikidataMatch = wikidataResults.find(item => item?.wd_code === code.wd_code);
 
       // Priority: Metabase name > Wikidata name > original name
-      const finalName = metabaseMatch?.name || wikidataMatch?.name || code.name;
+      const rawFinalName = metabaseMatch?.name || wikidataMatch?.name || code.name;
+      const finalName = sanitizeCapacityName(rawFinalName, code.code);
 
       finalResponse[code.code] = {
         name: finalName,

--- a/src/app/api/wikidata-labels/route.ts
+++ b/src/app/api/wikidata-labels/route.ts
@@ -1,0 +1,179 @@
+export const dynamic = 'force-dynamic';
+
+import { WIKIMEDIA_USER_AGENT } from '@/constants/wikimedia';
+import { NextRequest, NextResponse } from 'next/server';
+
+const isInvalidCapacityLabel = (name: string | undefined): boolean => {
+  if (!name?.trim()) return true;
+  const n = name.trim();
+  return n.startsWith('http') || n.includes('entity/') || /^Q\d+$/i.test(n);
+};
+
+type WikidataLabelMap = Record<string, { value?: string }>;
+
+const pickLabelFromEntity = (
+  entityLabels: WikidataLabelMap | undefined,
+  languageCandidates: string[]
+): string | undefined => {
+  if (!entityLabels) return undefined;
+
+  const langs = [...languageCandidates, 'en', 'pt-br', 'pt'];
+  const seen = new Set<string>();
+  for (const lang of langs) {
+    if (!lang || seen.has(lang)) continue;
+    seen.add(lang);
+    const candidate = entityLabels[lang]?.value;
+    if (candidate && !isInvalidCapacityLabel(candidate)) {
+      return candidate;
+    }
+  }
+
+  for (const labelData of Object.values(entityLabels)) {
+    if (labelData?.value && !isInvalidCapacityLabel(labelData.value)) {
+      return labelData.value;
+    }
+  }
+
+  return undefined;
+};
+
+const pickDescriptionFromEntity = (
+  entityDescriptions: WikidataLabelMap | undefined,
+  languageCandidates: string[]
+): string => {
+  if (!entityDescriptions) return '';
+
+  const langs = [...languageCandidates, 'en', 'pt-br', 'pt'];
+  const seen = new Set<string>();
+  for (const lang of langs) {
+    if (!lang || seen.has(lang)) continue;
+    seen.add(lang);
+    if (entityDescriptions[lang]?.value) {
+      return entityDescriptions[lang].value!;
+    }
+  }
+
+  return '';
+};
+
+const fetchEntityViaEntityData = async (
+  wd_code: string
+): Promise<{ labels?: WikidataLabelMap; descriptions?: WikidataLabelMap } | null> => {
+  const response = await fetch(
+    `https://www.wikidata.org/wiki/Special:EntityData/${encodeURIComponent(wd_code)}.json`,
+    {
+      headers: { 'User-Agent': WIKIMEDIA_USER_AGENT },
+      cache: 'no-store',
+    }
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = await response.json();
+  const entity =
+    data?.entities?.[wd_code] ??
+    data?.entities?.[wd_code.toUpperCase()] ??
+    Object.values(data?.entities ?? {}).find(
+      (e: { id?: string }) => e?.id?.toUpperCase() === wd_code.toUpperCase()
+    );
+
+  if (!entity || (entity as { missing?: string }).missing !== undefined) {
+    return null;
+  }
+
+  return entity as { labels?: WikidataLabelMap; descriptions?: WikidataLabelMap };
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const idsParam = searchParams.get('ids');
+    const languagesParam = searchParams.get('languages') || 'en';
+
+    if (!idsParam) {
+      return NextResponse.json({ error: 'ids parameter is required' }, { status: 400 });
+    }
+
+    const ids = idsParam
+      .split(',')
+      .map(id => id.trim())
+      .filter(Boolean);
+
+    if (ids.length === 0) {
+      return NextResponse.json({ labels: [] });
+    }
+
+    if (ids.length > 50) {
+      return NextResponse.json({ error: 'Maximum 50 ids per request' }, { status: 400 });
+    }
+
+    const languageCandidates = languagesParam.split('|').filter(Boolean);
+    const entities: Record<string, { labels?: WikidataLabelMap; descriptions?: WikidataLabelMap }> =
+      {};
+
+    // Batch request via wbgetentities
+    const wbResponse = await fetch(
+      `https://www.wikidata.org/w/api.php?${new URLSearchParams({
+        action: 'wbgetentities',
+        ids: ids.join('|'),
+        props: 'labels|descriptions',
+        languages: [...new Set([...languageCandidates, 'en'])].join('|'),
+        languagefallback: '1',
+        format: 'json',
+      })}`,
+      {
+        headers: { 'User-Agent': WIKIMEDIA_USER_AGENT },
+        cache: 'no-store',
+      }
+    );
+
+    if (wbResponse.ok) {
+      const data = await wbResponse.json();
+      if (!data.error) {
+        Object.assign(entities, data.entities ?? {});
+      }
+    }
+
+    const labels: Array<{ wd_code: string; name: string; description: string }> = [];
+
+    for (const wd_code of ids) {
+      type EntityData = { labels?: WikidataLabelMap; descriptions?: WikidataLabelMap };
+
+      let entity: EntityData | undefined =
+        entities[wd_code] ??
+        entities[wd_code.toUpperCase()] ??
+        (Object.entries(entities).find(([k]) => k.toUpperCase() === wd_code.toUpperCase())?.[1] as
+          | EntityData
+          | undefined);
+
+      if (!entity || (entity as { missing?: string }).missing !== undefined) {
+        entity = (await fetchEntityViaEntityData(wd_code)) ?? undefined;
+      }
+
+      let name = pickLabelFromEntity(entity?.labels, languageCandidates);
+
+      if (!name) {
+        const entityData = await fetchEntityViaEntityData(wd_code);
+        if (entityData) {
+          entity = entityData;
+          name = pickLabelFromEntity(entityData.labels, languageCandidates);
+        }
+      }
+
+      if (!name) continue;
+
+      labels.push({
+        wd_code,
+        name,
+        description: pickDescriptionFromEntity(entity?.descriptions, languageCandidates),
+      });
+    }
+
+    return NextResponse.json({ labels });
+  } catch (error) {
+    console.error('Error in wikidata-labels API:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/wikidata-sparql/route.ts
+++ b/src/app/api/wikidata-sparql/route.ts
@@ -1,0 +1,41 @@
+export const dynamic = 'force-dynamic';
+
+import { WIKIMEDIA_USER_AGENT } from '@/constants/wikimedia';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const query = searchParams.get('query');
+    const format = searchParams.get('format') || 'json';
+
+    if (!query?.trim()) {
+      return NextResponse.json({ error: 'query parameter is required' }, { status: 400 });
+    }
+
+    const response = await fetch(
+      `https://query.wikidata.org/sparql?${new URLSearchParams({ format, query })}`,
+      {
+        headers: {
+          Accept: 'application/sparql-results+json',
+          'User-Agent': WIKIMEDIA_USER_AGENT,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      console.error('Wikidata SPARQL error:', response.status, text.slice(0, 200));
+      return NextResponse.json(
+        { error: `Wikidata SPARQL error: ${response.status}` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error in wikidata-sparql API:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/events/components/EventsSearch.tsx
+++ b/src/app/events/components/EventsSearch.tsx
@@ -62,13 +62,8 @@ export function EventsSearch({
   const pageContent = usePageContent();
   const darkMode = useDarkMode();
   const [searchTerm, setSearchTerm] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
 
-  const {
-    events,
-    isLoading: isEventsLoading,
-    error: _eventsError,
-  } = useEvents(session?.user?.token, 100, 0, organizationId);
+  const { events, error: _eventsError } = useEvents(session?.user?.token, 100, 0, organizationId);
 
   const lastSearchRef = useRef<string>('');
 
@@ -94,7 +89,6 @@ export function EventsSearch({
         return;
       }
 
-      setIsLoading(true);
       onSearchStart?.();
 
       try {
@@ -118,7 +112,6 @@ export function EventsSearch({
         console.error('Error:', error);
         onSearchResults?.([]);
       } finally {
-        setIsLoading(false);
         onSearchEnd?.();
       }
     },

--- a/src/components/Popup.tsx
+++ b/src/components/Popup.tsx
@@ -34,7 +34,7 @@ const Popup = ({
   closeButtonClassName,
   footerClassName,
   minHeight = 'min-h-0 md:min-h-[400px]',
-  contentScrollable = false,
+  contentScrollable: _contentScrollable = false,
 }: PopupProps) => {
   const darkMode = useDarkMode();
   const pageContent = usePageContent();

--- a/src/lib/utils/capacitiesUtils.ts
+++ b/src/lib/utils/capacitiesUtils.ts
@@ -5,11 +5,10 @@ import CommunityIcon from '@/public/static/images/communities.svg';
 import OrganizationalIcon from '@/public/static/images/corporate_fare.svg';
 import LearningIcon from '@/public/static/images/local_library.svg';
 import TechnologyIcon from '@/public/static/images/wifi_tethering.svg';
-import { WIKIMEDIA_USER_AGENT } from '@/constants/wikimedia';
 import { Capacity } from '@/types/capacity';
 import axios from 'axios';
 import { Dispatch, SetStateAction } from 'react';
-import { getCurrentAppUrl } from './environment';
+import { getApiBaseUrl } from './environment';
 
 /**
  * Consolidated utility functions for handling capacity operations
@@ -30,6 +29,12 @@ const colorMap: Record<string, string> = {
   social: '#D35400',
   strategic: '#3498DB',
   technology: '#27AE60',
+};
+
+export const isInvalidCapacityLabel = (name: string | undefined): boolean => {
+  if (!name || !name.trim()) return true;
+  const n = name.trim();
+  return n.startsWith('http') || n.includes('entity/') || /^Q\d+$/i.test(n);
 };
 
 const filterMap: Record<string, string> = {
@@ -98,26 +103,31 @@ export const fetchCapacitiesWithFallback = async (
             const wikidataMatch = wikidataResults.find(wd => wd.wd_code === metabaseResult.wd_code);
 
             if (wikidataMatch && wikidataMatch.description) {
+              const resolvedName = isInvalidCapacityLabel(metabaseResult.name)
+                ? isInvalidCapacityLabel(wikidataMatch.name)
+                  ? sanitizeCapacityName(
+                      metabaseResult.name,
+                      metabaseResult.code ?? metabaseResult.wd_code
+                    )
+                  : wikidataMatch.name
+                : metabaseResult.name;
               return {
-                ...metabaseResult, // Keep metabase_code and other Metabase data
-                // Only use Wikidata description if Metabase description is empty
+                ...metabaseResult,
                 description: wikidataMatch.description,
-                // Keep Metabase name unless it's empty
-                name: metabaseResult.name || wikidataMatch.name,
+                name: resolvedName,
               };
             }
 
-            return metabaseResult; // No Wikidata match or description, use Metabase as-is
+            return metabaseResult;
           });
 
-          return mergedResults;
+          return applyWikidataNameFallback(mergedResults, language);
         } catch {
-          // If Wikidata fails, just use Metabase results as-is
+          // If Wikidata fails, continue with name fallback below
         }
       }
 
-      // All descriptions are present in Metabase results, return them
-      return metabaseResults;
+      return applyWikidataNameFallback(metabaseResults, language);
     }
 
     // Step 3: If no results from Metabase, try Wikidata as final fallback
@@ -213,6 +223,54 @@ export const toggleChildCapacities = async (
   setExpandedCapacities(prev => ({ ...prev, [parentCode]: true }));
 };
 
+/** Fetches human-readable labels via Wikidata Action API (reliable when SPARQL returns entity URIs). */
+export const fetchWikidataLabelsViaApi = async (
+  codes: Array<{ code?: number; wd_code: string }>,
+  language: string
+): Promise<Array<{ wd_code: string; name: string; code?: number; description: string }>> => {
+  const wdIds = codes.map(c => c.wd_code).filter(Boolean);
+  if (wdIds.length === 0) return [];
+
+  const langBase = language.split('-')[0];
+  const languageCandidates = [language, langBase, 'en'].filter(
+    (v, i, arr) => v && arr.indexOf(v) === i
+  );
+  const BATCH_SIZE = 50;
+  const results: Array<{ wd_code: string; name: string; code?: number; description: string }> = [];
+
+  const baseUrl = getApiBaseUrl();
+
+  for (let i = 0; i < wdIds.length; i += BATCH_SIZE) {
+    const batch = wdIds.slice(i, i + BATCH_SIZE);
+    let labelRows: Array<{ wd_code: string; name: string; description?: string }> = [];
+    try {
+      const response = await axios.get(`${baseUrl}/api/wikidata-labels`, {
+        params: {
+          ids: batch.join(','),
+          languages: languageCandidates.join('|'),
+        },
+      });
+      labelRows = response.data?.labels ?? [];
+    } catch {
+      // Proxy unavailable; skip batch
+    }
+
+    for (const row of labelRows) {
+      const codeEntry = codes.find(c => c.wd_code?.toUpperCase() === row.wd_code?.toUpperCase());
+      if (row.name && !isInvalidCapacityLabel(row.name)) {
+        results.push({
+          wd_code: row.wd_code,
+          name: row.name,
+          code: codeEntry?.code,
+          description: row.description || '',
+        });
+      }
+    }
+  }
+
+  return results;
+};
+
 export const fetchWikidata = async (codes: any, language: string) => {
   try {
     if (!codes || codes.length === 0 || !codes[0].wd_code) {
@@ -220,32 +278,73 @@ export const fetchWikidata = async (codes: any, language: string) => {
       return [];
     }
 
-    // Continue with Wikidata query...
     const wdCodeList = codes.map((code: any) => 'wd:' + code.wd_code);
     const queryText = `SELECT ?item ?itemLabel ?itemDescription WHERE {VALUES ?item {${wdCodeList.join(
       ' '
     )}} SERVICE wikibase:label { bd:serviceParam wikibase:language '${language},en'.}}`;
 
-    const wikidataResponse = await axios.get(
-      `https://query.wikidata.org/bigdata/namespace/wdq/sparql?format=json&query=${queryText}`,
-      { headers: { 'User-Agent': WIKIMEDIA_USER_AGENT } }
-    );
+    const baseUrl = getApiBaseUrl();
+    const wikidataResponse = await axios.get(`${baseUrl}/api/wikidata-sparql`, {
+      params: { format: 'json', query: queryText },
+    });
 
-    const results = (wikidataResponse.data.results.bindings || [])
+    const sparqlResults = (wikidataResponse.data.results.bindings || [])
       .filter(
         (wdItem: any) =>
           wdItem.item && wdItem.item.value && wdItem.itemLabel && wdItem.itemLabel.value
       )
-      .map((wdItem: any) => ({
-        wd_code: wdItem.item.value.split('/').slice(-1)[0],
-        name: wdItem.itemLabel.value,
-        description: wdItem.itemDescription?.value || '',
-      }));
+      .map((wdItem: any) => {
+        const rawLabel = wdItem.itemLabel.value;
+        const wd_code = wdItem.item.value.split('/').slice(-1)[0];
+        const codeEntry = codes.find(
+          (c: { wd_code: string }) => c.wd_code?.toUpperCase() === wd_code.toUpperCase()
+        );
+        return {
+          wd_code,
+          code: codeEntry?.code,
+          name: isInvalidCapacityLabel(rawLabel) ? '' : rawLabel,
+          description: wdItem.itemDescription?.value || '',
+        };
+      });
 
-    return results;
+    const stillNeedingLabels = codes.filter((code: { wd_code: string; code?: number }) => {
+      const match = sparqlResults.find(
+        (r: { wd_code: string }) => r.wd_code?.toUpperCase() === code.wd_code?.toUpperCase()
+      );
+      return !match || isInvalidCapacityLabel(match.name);
+    });
+
+    if (stillNeedingLabels.length === 0) {
+      return sparqlResults;
+    }
+
+    const apiLabels = await fetchWikidataLabelsViaApi(stillNeedingLabels, language);
+    const mergedByWdCode = new Map<string, (typeof sparqlResults)[0]>();
+
+    sparqlResults.forEach((r: { wd_code: string }) =>
+      mergedByWdCode.set(r.wd_code.toUpperCase(), r)
+    );
+    apiLabels.forEach(apiResult => {
+      mergedByWdCode.set(apiResult.wd_code.toUpperCase(), {
+        ...mergedByWdCode.get(apiResult.wd_code.toUpperCase()),
+        wd_code: apiResult.wd_code,
+        code: apiResult.code ?? mergedByWdCode.get(apiResult.wd_code.toUpperCase())?.code,
+        name: apiResult.name,
+        description:
+          apiResult.description ||
+          mergedByWdCode.get(apiResult.wd_code.toUpperCase())?.description ||
+          '',
+      });
+    });
+
+    return Array.from(mergedByWdCode.values());
   } catch (error) {
     console.error('❌ Error in fetchWikidata:', error);
-    return [];
+    try {
+      return await fetchWikidataLabelsViaApi(codes, language);
+    } catch {
+      return [];
+    }
   }
 };
 
@@ -300,7 +399,7 @@ export const fetchMetabase = async (codes: any, language: string): Promise<Capac
       SERVICE wikibase:label { bd:serviceParam wikibase:language '${language},en'. }}`;
 
     // Use environment-specific URL for server-side requests
-    const baseUrl = getCurrentAppUrl();
+    const baseUrl = getApiBaseUrl();
     const response = await axios.get(`${baseUrl}/api/metabase-sparql`, {
       params: {
         format: 'json',
@@ -340,9 +439,15 @@ export const fetchMetabase = async (codes: any, language: string): Promise<Capac
         const isDescriptionFallback =
           language !== 'en' && (descriptionLanguage === 'en' || descriptionValue.trim() === '');
 
+        const rawLabel = mbItem.itemLabel.value;
+        const wd_code = mbItem.value.value;
+        const codeEntry = codes.find(
+          (c: { wd_code: string }) => c.wd_code?.toUpperCase() === wd_code?.toUpperCase()
+        );
         const result = {
-          wd_code: mbItem.value.value,
-          name: mbItem.itemLabel.value,
+          code: codeEntry?.code,
+          wd_code,
+          name: isInvalidCapacityLabel(rawLabel) ? '' : rawLabel,
           description: mbItem.itemDescription?.value || '',
           item: mbItem.item.value,
           metabase_code: metabaseCode,
@@ -355,8 +460,6 @@ export const fetchMetabase = async (codes: any, language: string): Promise<Capac
         return result;
       });
 
-    // Language fallback detection is now handled above using SPARQL response metadata
-
     return results;
   } catch {
     // Silently handle errors
@@ -366,17 +469,51 @@ export const fetchMetabase = async (codes: any, language: string): Promise<Capac
 };
 
 export const sanitizeCapacityName = (name: string | undefined, code: string | number): string => {
-  // Case where the name is not defined or is empty
-  if (!name || name.trim() === '') {
+  if (isInvalidCapacityLabel(name)) {
     return `Capacity ${code}`;
   }
+  return name!.trim();
+};
 
-  // Check if the name looks like a QID (common format with Q followed by numbers)
-  if (name.startsWith('Q') && /^Q\d+$/.test(name)) {
-    return `Capacity ${code}`;
+/** Replaces Metabase URI/QID labels with Wikidata labels when available. */
+export const applyWikidataNameFallback = async (
+  results: Array<{ wd_code: string; name: string; code?: number; [key: string]: unknown }>,
+  language: string
+) => {
+  const needingNames = results.filter(r => isInvalidCapacityLabel(r.name));
+  if (needingNames.length === 0) {
+    return results;
   }
 
-  return name;
+  try {
+    const codes = needingNames.map(r => ({ code: r.code, wd_code: r.wd_code }));
+
+    // Prefer Action API proxy (reliable labels); SPARQL often returns entity URIs
+    const apiLabels = await fetchWikidataLabelsViaApi(codes, language);
+
+    return results.map(r => {
+      if (!isInvalidCapacityLabel(r.name)) {
+        return r;
+      }
+
+      const apiMatch = apiLabels.find(a => a.wd_code?.toUpperCase() === r.wd_code?.toUpperCase());
+      if (apiMatch && !isInvalidCapacityLabel(apiMatch.name)) {
+        return { ...r, name: apiMatch.name, code: r.code ?? apiMatch.code };
+      }
+
+      return {
+        ...r,
+        name: sanitizeCapacityName(r.name, r.code ?? 0),
+        code: r.code,
+      };
+    });
+  } catch {
+    return results.map(r =>
+      isInvalidCapacityLabel(r.name)
+        ? { ...r, name: sanitizeCapacityName(r.name, r.code ?? r.wd_code) }
+        : r
+    );
+  }
 };
 
 // =============================================================================

--- a/src/lib/utils/environment.ts
+++ b/src/lib/utils/environment.ts
@@ -57,3 +57,11 @@ export function getCurrentAppUrl(): string {
       );
   }
 }
+
+/** Base URL for same-origin API routes (avoids env mismatch on client). */
+export function getApiBaseUrl(): string {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return window.location.origin;
+  }
+  return getCurrentAppUrl();
+}

--- a/src/stores/capacityStore.ts
+++ b/src/stores/capacityStore.ts
@@ -3,7 +3,26 @@
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 import { QueryClient } from '@tanstack/react-query';
-import { getCapacityColor, getCapacityIcon } from '@/lib/utils/capacitiesUtils';
+import {
+  applyWikidataNameFallback,
+  getCapacityColor,
+  getCapacityIcon,
+  isInvalidCapacityLabel,
+  sanitizeCapacityName,
+} from '@/lib/utils/capacitiesUtils';
+
+const resolveCapacityDisplayName = (
+  translationName: string | undefined,
+  currentName: string | undefined,
+  code: number
+): string => {
+  for (const candidate of [translationName, currentName]) {
+    if (candidate && !isInvalidCapacityLabel(candidate)) {
+      return candidate;
+    }
+  }
+  return sanitizeCapacityName(currentName ?? translationName, code);
+};
 import { capacityService } from '@/services/capacityService';
 import { CapacityStore, CapacityData, UnifiedCache } from './types';
 
@@ -61,10 +80,13 @@ export const useCapacityStore = create<CapacityStore>()(
         // Getter methods
         getName: (code: number): string => {
           const capacity = get().capacities[code];
-          if (capacity?.name) {
-            return capacity.name.charAt(0).toUpperCase() + capacity.name.slice(1).toLowerCase();
+          if (!capacity?.name) {
+            return `Capacity ${code}`;
           }
-          return `Capacity ${code}`;
+          if (isInvalidCapacityLabel(capacity.name)) {
+            return sanitizeCapacityName(capacity.name, code);
+          }
+          return capacity.name.charAt(0).toUpperCase() + capacity.name.slice(1).toLowerCase();
         },
 
         getDescription: (code: number): string => {
@@ -119,8 +141,15 @@ export const useCapacityStore = create<CapacityStore>()(
 
           const state = get();
 
-          // Check if already loaded for this language
-          if (state.language === newLanguage && Object.keys(state.capacities).length > 0) {
+          // Check if already loaded for this language (re-fetch if cache has URI/QID labels)
+          const hasInvalidCachedNames = Object.values(state.capacities).some(cap =>
+            isInvalidCapacityLabel(cap.name)
+          );
+          if (
+            state.language === newLanguage &&
+            Object.keys(state.capacities).length > 0 &&
+            !hasInvalidCachedNames
+          ) {
             if (!state.isLoaded) {
               set({ isLoaded: true });
             }
@@ -141,9 +170,13 @@ export const useCapacityStore = create<CapacityStore>()(
                 const cached = localStorage.getItem('capx-unified-cache');
                 if (cached) {
                   const parsed = JSON.parse(cached);
+                  const parsedHasInvalidNames = Object.values(parsed.capacities || {}).some(
+                    (cap: { name?: string }) => isInvalidCapacityLabel(cap.name)
+                  );
                   if (
                     parsed.language === newLanguage &&
-                    Object.keys(parsed.capacities).length > 0
+                    Object.keys(parsed.capacities).length > 0 &&
+                    !parsedHasInvalidNames
                   ) {
                     set({
                       capacities: parsed.capacities,
@@ -186,7 +219,7 @@ export const useCapacityStore = create<CapacityStore>()(
 
               newCache.capacities[capacity.code] = {
                 code: capacity.code,
-                name: capacity.name,
+                name: sanitizeCapacityName(capacity.name, capacity.code),
                 description: capacity.description || '',
                 wd_code: capacity.wd_code || '',
                 metabase_code: capacity.metabase_code || '',
@@ -222,10 +255,10 @@ export const useCapacityStore = create<CapacityStore>()(
                     const childCodeNum = parseInt(childCode, 10);
                     const hierarchyInfo = getHierarchyInfo(Number(rootCapacity.code));
 
-                    const childName =
-                      typeof childData === 'string'
-                        ? childData
-                        : (childData as any)?.name || `Capacity ${childCode}`;
+                    const childName = sanitizeCapacityName(
+                      typeof childData === 'string' ? childData : (childData as any)?.name || '',
+                      childCodeNum
+                    );
 
                     newCache.capacities[childCodeNum] = {
                       code: childCodeNum,
@@ -270,10 +303,12 @@ export const useCapacityStore = create<CapacityStore>()(
 
                           for (const [grandchildCode, grandchildData] of grandchildrenEntries) {
                             const grandchildCodeNum = parseInt(grandchildCode, 10);
-                            const grandchildName =
+                            const grandchildName = sanitizeCapacityName(
                               typeof grandchildData === 'string'
                                 ? grandchildData
-                                : (grandchildData as any)?.name || `Capacity ${grandchildCode}`;
+                                : (grandchildData as any)?.name || '',
+                              grandchildCodeNum
+                            );
 
                             newCache.capacities[grandchildCodeNum] = {
                               code: grandchildCodeNum,
@@ -333,20 +368,40 @@ export const useCapacityStore = create<CapacityStore>()(
                 );
                 if (matchingCapacity && newCache.capacities[matchingCapacity.code]) {
                   const currentCapacity = newCache.capacities[matchingCapacity.code];
+                  const mergedName = resolveCapacityDisplayName(
+                    translation.name,
+                    currentCapacity.name,
+                    matchingCapacity.code
+                  );
                   newCache.capacities[matchingCapacity.code] = {
                     ...currentCapacity,
-                    name:
-                      currentCapacity.level === 1
-                        ? translation.name || currentCapacity.name
-                        : translation.name && translation.name !== currentCapacity.name
-                          ? translation.name
-                          : currentCapacity.name,
+                    name: mergedName,
                     isFallbackLabel: translation.isFallbackLabel || false,
                     isFallbackDescription: translation.isFallbackDescription || false,
                     isFallbackTranslation: translation.isFallbackTranslation || false,
                     description: translation.description || currentCapacity.description,
                     metabase_code: translation.metabase_code || currentCapacity.metabase_code,
                   };
+                }
+              });
+            }
+
+            // Final pass: resolve any remaining URI/QID labels via Wikidata
+            const stillInvalid = Object.values(newCache.capacities).filter(
+              cap => isInvalidCapacityLabel(cap.name) && cap.wd_code?.trim()
+            );
+            if (stillInvalid.length > 0) {
+              const resolved = await applyWikidataNameFallback(
+                stillInvalid.map(cap => ({
+                  code: cap.code,
+                  wd_code: cap.wd_code!,
+                  name: cap.name,
+                })),
+                newLanguage
+              );
+              resolved.forEach(item => {
+                if (newCache.capacities[item.code as number]) {
+                  newCache.capacities[item.code as number].name = item.name;
                 }
               });
             }


### PR DESCRIPTION
run yarn format
fix some warnings on build
fix capacities showing entity URLs or "Capacity {id}" instead of human-readable labels (e.g. Fountain for Q80180815).