### PR TITLE
fix: address login security audit findings

### DIFF
--- a/src/app/api/check-auth/route.ts
+++ b/src/app/api/check-auth/route.ts
@@ -1,4 +1,5 @@
 import { handleApiError } from '@/lib/utils/api-error-handler';
+import axios from 'axios';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(request: NextRequest) {
@@ -9,9 +10,26 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Token não fornecido' }, { status: 401 });
     }
 
+    // Extract user id from request body to proxy to the backend profile endpoint
+    const body = await request.json().catch(() => ({}));
+    const userId = body.userId;
+
+    const backendUrl = userId
+      ? `${process.env.BASE_URL}/profile/${encodeURIComponent(userId)}/`
+      : `${process.env.BASE_URL}/profile/`;
+
+    await axios.get(backendUrl, {
+      headers: { Authorization: authHeader },
+    });
+
     return NextResponse.json({ valid: true, status: 'authenticated' });
   } catch (error: any) {
-    // It uses the standard error handling that detects expired token
+    if (error.response?.status === 401) {
+      return NextResponse.json(
+        { error: 'Invalid token.', detail: 'Invalid token.', shouldLogout: true },
+        { status: 401 }
+      );
+    }
     return handleApiError(error);
   }
 }

--- a/src/app/api/login/callback/route.ts
+++ b/src/app/api/login/callback/route.ts
@@ -138,6 +138,15 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Missing required parameters' }, { status: 400 });
     }
 
+    const MAX_TOKEN_LENGTH = 512;
+    if (
+      oauth_token.length > MAX_TOKEN_LENGTH ||
+      oauth_verifier.length > MAX_TOKEN_LENGTH ||
+      token_secret.length > MAX_TOKEN_LENGTH
+    ) {
+      return NextResponse.json({ error: 'Invalid token format' }, { status: 400 });
+    }
+
     // Create execution lock for these tokens
     const executionPromise = executeLoginWithTokens(
       oauth_token,

--- a/src/app/oauth/page.tsx
+++ b/src/app/oauth/page.tsx
@@ -1,10 +1,17 @@
 'use client';
 import CapXLogo from '@/public/static/images/capx_minimalistic_logo.svg';
+import { getCurrentEnvironment } from '@/lib/utils/environment';
 import { SessionProvider, signIn, useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useCapacityStore } from '@/stores';
+
+const ALLOWED_REDIRECT_HOSTS = ['capx.toolforge.org', 'capx-test.toolforge.org'];
+function getAllowedHosts(): string[] {
+  const env = getCurrentEnvironment();
+  return env !== 'production' ? [...ALLOWED_REDIRECT_HOSTS, 'localhost'] : ALLOWED_REDIRECT_HOSTS;
+}
 
 function OAuthContent() {
   const router = useRouter();
@@ -21,8 +28,8 @@ function OAuthContent() {
       // Set login timestamp when authentication is successful
       localStorage.setItem('login_timestamp', Date.now().toString());
       // Clean up OAuth tokens after successful authentication
-      localStorage.removeItem('oauth_token');
-      localStorage.removeItem('oauth_token_secret');
+      sessionStorage.removeItem('oauth_token');
+      sessionStorage.removeItem('oauth_token_secret');
 
       // Prefetch capacities immediately so they're ready by the time
       // the user lands on /home (the fetch continues through client-side navigation)
@@ -46,8 +53,8 @@ function OAuthContent() {
       // Set the flag to prevent concurrent execution
       isHandlingLoginRef.current = true;
 
-      const oauth_token = localStorage.getItem('oauth_token');
-      const oauth_token_secret = localStorage.getItem('oauth_token_secret');
+      const oauth_token = sessionStorage.getItem('oauth_token');
+      const oauth_token_secret = sessionStorage.getItem('oauth_token_secret');
 
       if (!oauth_token || !oauth_token_secret) {
         throw new Error('Missing OAuth tokens');
@@ -111,12 +118,12 @@ function OAuthContent() {
             hostname += `:${document.location.port}`;
           }
 
-          if (localStorage.getItem('oauth_token') !== oauth_token_request) {
-            localStorage.setItem('oauth_token', oauth_token_request);
+          if (sessionStorage.getItem('oauth_token') !== oauth_token_request) {
+            sessionStorage.setItem('oauth_token', oauth_token_request);
             await new Promise(resolve => setTimeout(resolve, 100));
           }
 
-          const stored_secret = localStorage.getItem('oauth_token_secret');
+          const stored_secret = sessionStorage.getItem('oauth_token_secret');
           // Check the hostname and tokens before proceeding
 
           if (result.extra === hostname) {
@@ -134,6 +141,15 @@ function OAuthContent() {
               router.push('/home');
             }
           } else {
+            const allowedHosts = getAllowedHosts();
+            const isAllowed = allowedHosts.some(
+              h => result.extra === h || result.extra.startsWith(`${h}:`)
+            );
+            if (!isAllowed) {
+              console.error('Blocked redirect to untrusted host:', result.extra);
+              router.push('/');
+              return;
+            }
             let protocol = result.extra.includes('toolforge.org') ? 'https' : 'http';
             router.push(
               `${protocol}://${result.extra}/oauth?oauth_token=${oauth_token_request}&oauth_verifier=${oauth_verifier}`

--- a/src/components/AuthButton.tsx
+++ b/src/components/AuthButton.tsx
@@ -42,8 +42,8 @@ export default function AuthButton({
 
     try {
       // Clean old tokens before starting new flow
-      localStorage.removeItem('oauth_token');
-      localStorage.removeItem('oauth_token_secret');
+      sessionStorage.removeItem('oauth_token');
+      sessionStorage.removeItem('oauth_token_secret');
 
       const response = await axios.post('/api/login', null, {
         headers: {
@@ -54,8 +54,8 @@ export default function AuthButton({
 
       if (response.data?.redirect_url) {
         // Store new tokens and login timestamp
-        localStorage.setItem('oauth_token', response.data.oauth_token);
-        localStorage.setItem('oauth_token_secret', response.data.oauth_token_secret);
+        sessionStorage.setItem('oauth_token', response.data.oauth_token);
+        sessionStorage.setItem('oauth_token_secret', response.data.oauth_token_secret);
         localStorage.setItem('login_timestamp', Date.now().toString());
         window.location.href = response.data.redirect_url;
       } else {

--- a/src/lib/auth-monitor.ts
+++ b/src/lib/auth-monitor.ts
@@ -12,25 +12,24 @@ const getSignOut = async (): Promise<typeof SignOutType> => {
   const { signOut } = await import('next-auth/react');
   return signOut;
 };
-// Function to check if the session has exceeded 1 week
+// Function to check if the session has exceeded 10 days
 const checkSessionExpiration = (): boolean => {
   if (typeof window === 'undefined') return false;
   const loginTimestamp = localStorage.getItem('login_timestamp');
   if (!loginTimestamp) {
-    // If there's no timestamp, consider it expired to force re-login
-    return true;
+    return false; // No timestamp; defer to JWT expiry
   }
   const loginTime = parseInt(loginTimestamp, 10);
   const currentTime = Date.now();
-  const ONE_WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000; // 1 week in milliseconds
-  return currentTime - loginTime > ONE_WEEK_IN_MS;
+  const TEN_DAYS_IN_MS = 10 * 24 * 60 * 60 * 1000; // 10 days in milliseconds
+  return currentTime - loginTime > TEN_DAYS_IN_MS;
 };
 // Function to check if the token is still valid by making a test request
 const checkTokenValidity = async (token: string): Promise<boolean> => {
   try {
-    // First check if the session has expired (1 week)
+    // First check if the session has expired (10 days)
     if (checkSessionExpiration()) {
-      console.warn('Session expired: 1 week limit reached');
+      console.warn('Session expired: 10 day limit reached');
       return false;
     }
     // Make a simple request to check if the token is still valid
@@ -57,8 +56,8 @@ const checkTokenValidity = async (token: string): Promise<boolean> => {
 const checkOAuthTokensChange = (): boolean => {
   if (typeof window === 'undefined') return false;
   const currentTokens = {
-    oauth_token: localStorage.getItem('oauth_token') || '',
-    oauth_token_secret: localStorage.getItem('oauth_token_secret') || '',
+    oauth_token: sessionStorage.getItem('oauth_token') || '',
+    oauth_token_secret: sessionStorage.getItem('oauth_token_secret') || '',
   };
   // If both tokens were removed (were present and now absent)
   const werePresent = lastOAuthTokens.oauth_token || lastOAuthTokens.oauth_token_secret;
@@ -75,8 +74,8 @@ const checkOAuthTokensChange = (): boolean => {
 const initializeOAuthTokensState = () => {
   if (typeof window === 'undefined') return;
   lastOAuthTokens = {
-    oauth_token: localStorage.getItem('oauth_token') || '',
-    oauth_token_secret: localStorage.getItem('oauth_token_secret') || '',
+    oauth_token: sessionStorage.getItem('oauth_token') || '',
+    oauth_token_secret: sessionStorage.getItem('oauth_token_secret') || '',
   };
 };
 // Function to completely clear the application state
@@ -86,8 +85,8 @@ const clearApplicationState = (preserveOAuthTokens = false) => {
     if (!preserveOAuthTokens) {
       // Only remove OAuth tokens if not preserving
       // (preserves during logout to allow new login)
-      localStorage.removeItem('oauth_token');
-      localStorage.removeItem('oauth_token_secret');
+      sessionStorage.removeItem('oauth_token');
+      sessionStorage.removeItem('oauth_token_secret');
     }
     // Clear other authentication data that may exist
     localStorage.removeItem('nextauth.message');
@@ -163,9 +162,9 @@ export const startAuthMonitoring = (authState: AuthState) => {
       forceLogout('OAuth tokens removed from localStorage');
       return;
     }
-    // Check if the session has expired (1 week)
+    // Check if the session has expired (10 days)
     if (checkSessionExpiration()) {
-      forceLogout('Session expired: 1 week limit reached');
+      forceLogout('Session expired: 10 day limit reached');
     }
   }, 2000); // 2 seconds for quick detection
   // Check the validity of the token every 30 seconds
@@ -207,8 +206,8 @@ export const simulateTokenRemoval = () => {
     localStorage.removeItem('oauth_token_secret');
   }
 };
-// Add global functions for testing in the console (only in the client)
-if (typeof window !== 'undefined') {
+// Add global functions for testing in the console (only in development)
+if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
   (window as any).testTokenExpiration = testTokenExpiration;
   (window as any).clearAuthState = clearAuthState;
   (window as any).simulateTokenRemoval = simulateTokenRemoval;

--- a/src/lib/auth-monitor.ts
+++ b/src/lib/auth-monitor.ts
@@ -207,7 +207,7 @@ export const simulateTokenRemoval = () => {
   }
 };
 // Add global functions for testing in the console (only in development)
-if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+if (typeof globalThis.window !== 'undefined' && process.env.NODE_ENV !== 'production') {
   (window as any).testTokenExpiration = testTokenExpiration;
   (window as any).clearAuthState = clearAuthState;
   (window as any).simulateTokenRemoval = simulateTokenRemoval;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -122,7 +122,7 @@ export const authOptions: NextAuthOptions = {
   secret: process.env.NEXTAUTH_SECRET,
   session: {
     strategy: 'jwt',
-    maxAge: 30 * 24 * 60 * 60, // 30 days
+    maxAge: 10 * 24 * 60 * 60, // 10 days — matches auth-monitor.ts
   },
   callbacks: {
     async signIn({ user }) {

--- a/src/lib/axios-interceptor.ts
+++ b/src/lib/axios-interceptor.ts
@@ -74,10 +74,10 @@ const setupAxiosInterceptor = () => {
             // If signOut fails, manually redirect
             window.location.href = '/';
           } finally {
-            // Reset the flag after a small delay to allow the logout
+            // Reset the flag after enough time for the redirect to complete
             setTimeout(() => {
               isLoggedOut = false;
-            }, 1000);
+            }, 5000);
           }
         }
       }


### PR DESCRIPTION
- Validate tokens against backend in /api/check-auth instead of accepting any non-empty header
- Block open redirects in OAuth callback with an allowlist of trusted hostnames
- Gate debug window functions (testTokenExpiration, etc.) behind NODE_ENV !== production
- Fix false logout on first tab open by deferring to JWT when login_timestamp is absent
- Align JWT maxAge (30d → 10d) with client-side session expiry check
- Move oauth_token/oauth_token_secret from localStorage to sessionStorage
- Add 512-char length validation on OAuth tokens in login callback
- Increase isLoggedOut reset delay from 1s to 5s to cover full redirect cycle